### PR TITLE
Specification tip subsets in liquid handling operations

### DIFF
--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -5,4 +5,4 @@ from . liquidhandling import Labware, Trough, VolumeOverflowError, VolumeUnderfl
 from . utils import DilutionPlan, get_trough_wells
 from . transform import WellShifter, WellRotator, make_well_array, make_well_index_dict
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'

--- a/robotools/evotools/__init__.py
+++ b/robotools/evotools/__init__.py
@@ -35,7 +35,7 @@ class InvalidOperationError(Exception):
     pass
 
 
-def _prepate_aspirate_dispense_parameters(
+def _prepare_aspirate_dispense_parameters(
     rack_label:str, position:int, volume:float,
     liquid_class:str='',
     tip:typing.Union[Tip, int]=Tip.Any,
@@ -422,7 +422,7 @@ class Worklist(list):
             Overrides rack_type from worktable
         """
         args = (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type)
-        (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type) = _prepate_aspirate_dispense_parameters(*args, max_volume=self.max_volume)
+        (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type) = _prepare_aspirate_dispense_parameters(*args, max_volume=self.max_volume)
         tip_type = ''
         self.append(
             f'A;{rack_label};{rack_id};{rack_type};{position};{tube_id};{volume};{liquid_class};{tip_type};{tip};{forced_rack_type}'
@@ -463,7 +463,7 @@ class Worklist(list):
             Overrides rack_type from worktable
         """
         args = (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type)
-        (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type) = _prepate_aspirate_dispense_parameters(*args, max_volume=self.max_volume)
+        (rack_label, position, volume, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type) = _prepare_aspirate_dispense_parameters(*args, max_volume=self.max_volume)
         tip_type = ''
         self.append(
             f'D;{rack_label};{rack_id};{rack_type};{position};{tube_id};{volume};{liquid_class};{tip_type};{tip};{forced_rack_type}'
@@ -536,10 +536,10 @@ class Worklist(list):
             exclude_wells = ''
 
         src_args = (src_rack_label, 1, volume, '', Tip.Any, src_rack_id, '', src_rack_type, '')
-        (src_rack_label, _, _, _, _, src_rack_id, _, src_rack_type, _) = _prepate_aspirate_dispense_parameters(*src_args, max_volume=self.max_volume)
+        (src_rack_label, _, _, _, _, src_rack_id, _, src_rack_type, _) = _prepare_aspirate_dispense_parameters(*src_args, max_volume=self.max_volume)
 
         dst_args = (dst_rack_label, 1, volume, '', Tip.Any, dst_rack_id, '', dst_rack_type, '')
-        (dst_rack_label, _, _, _, _, dst_rack_id, _, dst_rack_type, _) = _prepate_aspirate_dispense_parameters(*dst_args, max_volume=self.max_volume)
+        (dst_rack_label, _, _, _, _, dst_rack_id, _, dst_rack_type, _) = _prepare_aspirate_dispense_parameters(*dst_args, max_volume=self.max_volume)
 
         # automatically decrease multi_disp to support the large volume
         # at the expense of more washing

--- a/robotools/tests.py
+++ b/robotools/tests.py
@@ -247,66 +247,66 @@ class TestWorklist(unittest.TestCase):
 
     def test_parameter_validation(self):
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='thisisaveryverylongracklabelthatexceedsthemaximumlength', position=1, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='thisisaveryverylongracklabelthatexceedsthemaximumlength', position=1, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='rack label; with semicolon', position=1, volume=15)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='valid rack label', position=1, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='rack label; with semicolon', position=1, volume=15)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='valid rack label', position=1, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=None, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=None, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position='3', volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position='3', volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=-1, volume=15)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=-1, volume=15)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='nan')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='nan')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=float('nan'))
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=float('nan'))
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=-15.4)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=-15.4)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='bla')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='15')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=20)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=23.78)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=numpy.array(23.4))
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='bla')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume='15')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=20)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=23.78)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=numpy.array(23.4))
         
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='liquid;class')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='valid liquid class')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='liquid;class')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='valid liquid class')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=12)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=4)
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=evotools.Tip.T5)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=12)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=4)
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=evotools.Tip.T5)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='invalid;rack')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='invalid;rack')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='thisisaveryverylongrackthatexceedsthemaximumlength')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='1235464')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='thisisaveryverylongrackthatexceedsthemaximumlength')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id='1235464')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='invalid;rack type')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='invalid;rack type')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='thisisaveryverylongracktypethatexceedsthemaximumlength')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='valid rack type')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='thisisaveryverylongracktypethatexceedsthemaximumlength')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_type='valid rack type')
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type=None)
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type=None)
         with self.assertRaises(ValueError):
-            evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type='invalid;forced rack type')
-        evotools._prepate_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type='valid forced rack type')
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type='invalid;forced rack type')
+        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, forced_rack_type='valid forced rack type')
         return
 
     def test_comment(self):

--- a/robotools/tests.py
+++ b/robotools/tests.py
@@ -282,12 +282,32 @@ class TestWorklist(unittest.TestCase):
         with self.assertRaises(ValueError):
             evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='liquid;class')
         evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, liquid_class='valid liquid class')
-        with self.assertRaises(ValueError):
+
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=4)
+        assert tip == 8
+        _, _, _, _, tip, _, _, _, _  = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=evotools.Tip.T5)
+        assert tip == 16
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=(evotools.Tip.T4, 4))
+        assert tip == 8
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=[evotools.Tip.T1, 4])
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=[1, 4])
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=[1, evotools.Tip.T4])
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=evotools.Tip.Any)
+        assert tip == ''
+    
+        with pytest.raises(ValueError, match='no Tip.Any elements are allowed'):
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=(evotools.Tip.T1, evotools.Tip.Any))
+        with pytest.raises(ValueError, match='tip must be an int between 1 and 8, Tip or Iterable'):
             evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=None)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError, match='it may only contain int or Tip values'):
+            evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=[1, 2.6])
+        with pytest.raises(ValueError, match='should be an int between 1 and 8 for _int_to_tip'):
             evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=12)
-        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=4)
-        evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, tip=evotools.Tip.T5)
+
+        
         with self.assertRaises(ValueError):
             evotools._prepare_aspirate_dispense_parameters(rack_label='WaterTrough', position=1, volume=15, rack_id=None)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR adds functionality to not only specify one specific Tecan tip per aspirate or dispense, but rather lists of tips to be used.

For this, the `_pepare_aspirate_dispense_parameters` function was modified to accept integers between 1 and 8 (referring to the tips), `evotools.Tip` objects or iterables containing elements of the former two.

Tests were added respectively.