### PR TITLE
Modify user-API of `evo_*` commands to 1-based site numbers

### DIFF
--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -11,4 +11,4 @@ from .transform import (
 )
 from .utils import DilutionPlan, get_trough_wells
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"

--- a/robotools/evotools/commands.py
+++ b/robotools/evotools/commands.py
@@ -108,7 +108,8 @@ def prepare_evo_aspirate_dispense_parameters(
     wells : list of str
         List with target well ID(s)
     labware_position : tuple
-        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2).
+        NOTE: The site numbering starts at 1.
     volume : int, float or list
         Volume in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
     liquid_class : str, optional
@@ -123,7 +124,8 @@ def prepare_evo_aspirate_dispense_parameters(
     wells : list of str
         List with target well ID(s)
     labware_position : tuple
-        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2).
+        NOTE: The returned site number starts at 1.
     volume : list
         Volume in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
     liquid_class : str, optional
@@ -139,10 +141,12 @@ def prepare_evo_aspirate_dispense_parameters(
         raise ValueError(f"Invalid wells: wells and tips need to have the same length.")
     if labware_position is None:
         raise ValueError("Missing required parameter: position")
-    if not all(isinstance(position, int) for position in labware_position) or any(
-        position < 0 for position in labware_position
-    ):
-        raise ValueError(f"Invalid position: {labware_position}")
+    grid, site = labware_position
+    if not isinstance(grid, int) or not 1 <= grid <= 67:
+        raise ValueError("Grid (first number in labware_position tuple) has to be an int from 1 - 67.")
+    if not isinstance(site, int) or not 1 <= site <= 128:
+        raise ValueError("Site (second number in labware_position tuple) has to be an int from 1 - 128.")
+    labware_position = (grid, site - 1)
 
     if volume is None:
         raise ValueError("Missing required parameter: volume")
@@ -220,7 +224,8 @@ def evo_aspirate(
     wells : list of str
         List with target well ID(s)
     labware_position : tuple
-        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2).
+        NOTE: The site numbering starts at 1.
     volume : int, float or list
         Volume in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
     liquid_class : str, optional
@@ -293,7 +298,8 @@ def evo_dispense(
     wells : list of str
         List with target well ID(s)
     labware_position : tuple
-        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2).
+        NOTE: The site numbering starts at 1.
     volume : int, float or list
         Volume in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
     liquid_class : str, optional
@@ -363,9 +369,9 @@ def prepare_evo_wash_parameters(
     tips : list
         Tip(s) that will be selected; use either a list with integers from 1 - 8 or with tip.T1 - tip.T8
     waste_location : tuple
-        Tuple with grid position (1-67) and site number (0-127) of waste as integers
+        Tuple with grid position (1-67) and site number (1-128) of waste as integers
     cleaner_location : tuple
-        Tuple with grid position (1-67) and site number (0-127) of cleaner as integers
+        Tuple with grid position (1-67) and site number (1-128) of cleaner as integers
     arm : int
         number of the LiHa performing the action: 0 = LiHa 1, 1 = LiHa 2
     waste_vol: float
@@ -431,16 +437,18 @@ def prepare_evo_wash_parameters(
     grid, site = waste_location
     if not isinstance(grid, int) or not 1 <= grid <= 67:
         raise ValueError("Grid (first number in waste_location tuple) has to be an int from 1 - 67.")
-    if not isinstance(site, int) or not 0 <= site <= 127:
-        raise ValueError("Site (second number in waste_location tuple) has to be an int from 0 - 127.")
+    if not isinstance(site, int) or not 1 <= site <= 128:
+        raise ValueError("Site (second number in waste_location tuple) has to be an int from 1 - 128.")
+    waste_location = (grid, site - 1)
 
     if cleaner_location is None:
         raise ValueError("Missing required parameter: cleaner_location")
     grid, site = cleaner_location
     if not isinstance(grid, int) or not 1 <= grid <= 67:
         raise ValueError("Grid (first number in cleaner_location tuple) has to be an int from 1 - 67.")
-    if not isinstance(site, int) or not 0 <= site <= 127:
-        raise ValueError("Site (second number in cleaner_location tuple) has to be an int from 0 - 127.")
+    if not isinstance(site, int) or not 1 <= site <= 128:
+        raise ValueError("Site (second number in cleaner_location tuple) has to be an int from 1 - 128.")
+    cleaner_location = (grid, site - 1)
 
     if arm is None:
         raise ValueError("Missing required paramter: arm")
@@ -544,9 +552,9 @@ def evo_wash(
     tips : list
         Tip(s) that will be selected; use either a list with integers from 1 - 8 or with tip.T1 - tip.T8
     waste_location : tuple
-        Tuple with grid position (1-67) and site number (0-127) of waste as integers
+        Tuple with grid position (1-67) and site number (1-128) of waste as integers
     cleaner_location : tuple
-        Tuple with grid position (1-67) and site number (0-127) of cleaner as integers
+        Tuple with grid position (1-67) and site number (1-128) of cleaner as integers
     arm : int
         number of the LiHa performing the action: 0 = LiHa 1, 1 = LiHa 2
     waste_vol: float

--- a/robotools/evotools/test_commands.py
+++ b/robotools/evotools/test_commands.py
@@ -50,15 +50,15 @@ class TestPrepareEvoAspirateDispenseParameters:
                 tips=[1, 2],
             )
         # test labware_position argument checks
-        with pytest.raises(ValueError, match="Invalid position:"):
+        with pytest.raises(ValueError, match="second number in labware_position"):
             prepare_evo_aspirate_dispense_parameters(
                 wells=["A01", "B01"],
-                labware_position=(38, -1),
+                labware_position=(38, 0),
                 volume=15,
                 liquid_class="Water_DispZmax-1_AspZmax-1",
                 tips=[1, 2],
             )
-        with pytest.raises(ValueError, match="Invalid position:"):
+        with pytest.raises(ValueError, match="first number in labware_position"):
             prepare_evo_aspirate_dispense_parameters(
                 wells=["A01", "B01"],
                 labware_position=("a", 2),
@@ -132,7 +132,7 @@ class TestPrepareEvoAspirateDispenseParameters:
         # test complete prepare_evo_aspirate_dispense_parameters() command
         actual = prepare_evo_aspirate_dispense_parameters(
             wells=["E01", "F01", "G01"],
-            labware_position=(38, 2),
+            labware_position=(38, 3),
             volume=750,
             liquid_class="Water_DispZmax_AspZmax",
             tips=[5, 6, 7],
@@ -153,7 +153,7 @@ class TestEvoAspirate:
             n_rows=8,
             n_columns=12,
             wells=["E01", "F01", "G01"],
-            labware_position=(38, 2),
+            labware_position=(38, 3),
             tips=[5, 6, 7],
             volume=750,
             liquid_class="Water_DispZmax_AspZmax",
@@ -168,7 +168,7 @@ class TestEvoAspirate:
             n_rows=8,
             n_columns=12,
             wells=["E01", "F01", "G01"],
-            labware_position=(38, 2),
+            labware_position=(38, 3),
             tips=[5, 6, 7],
             volume=[750, 730, 710],
             liquid_class="Water_DispZmax_AspZmax",
@@ -185,7 +185,7 @@ class TestEvoDispense:
             n_rows=8,
             n_columns=12,
             wells=["E01", "F01", "G01"],
-            labware_position=(38, 2),
+            labware_position=(38, 3),
             tips=[5, 6, 7],
             volume=750,
             liquid_class="Water_DispZmax_AspZmax",
@@ -200,7 +200,7 @@ class TestEvoDispense:
             n_rows=8,
             n_columns=12,
             wells=["E01", "F01", "G01"],
-            labware_position=(38, 2),
+            labware_position=(38, 3),
             tips=[5, 6, 7],
             volume=[750, 730, 710],
             liquid_class="Water_DispZmax_AspZmax",
@@ -216,8 +216,8 @@ class TestEvoWash:
         # test tips argument checks
         tips, _, _, _, _, _, _, _, _, _, _, _, _ = prepare_evo_wash_parameters(
             tips=[1, 2],
-            waste_location=(52, 1),
-            cleaner_location=(52, 0),
+            waste_location=(52, 2),
+            cleaner_location=(52, 1),
         )
         if not all(isinstance(n, Tip) for n in tips):
             raise TypeError(
@@ -228,38 +228,38 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="Grid \\(first number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(68, 1),
-                cleaner_location=(52, 0),
+                waste_location=(68, 2),
+                cleaner_location=(52, 1),
             )
         with pytest.raises(ValueError, match="Grid \\(first number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(0, 1),
-                cleaner_location=(52, 0),
+                waste_location=(0, 2),
+                cleaner_location=(52, 1),
             )
         with pytest.raises(ValueError, match="Grid \\(first number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(1.7, 1),
-                cleaner_location=(52, 0),
+                waste_location=(1.7, 2),
+                cleaner_location=(52, 1),
             )
         with pytest.raises(ValueError, match="Site \\(second number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, -1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 0),
+                cleaner_location=(52, 1),
             )
         with pytest.raises(ValueError, match="Site \\(second number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 128),
-                cleaner_location=(52, 0),
+                waste_location=(52, 129),
+                cleaner_location=(52, 1),
             )
         with pytest.raises(ValueError, match="Site \\(second number in waste_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
                 waste_location=(52, 1.7),
-                cleaner_location=(52, 0),
+                cleaner_location=(52, 1),
             )
 
         # test cleaner_location argument checks
@@ -285,13 +285,13 @@ class TestEvoWash:
             prepare_evo_wash_parameters(
                 tips=[1, 2],
                 waste_location=(52, 1),
-                cleaner_location=(52, -1),
+                cleaner_location=(52, 0),
             )
         with pytest.raises(ValueError, match="Site \\(second number in cleaner_location tuple\\)"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
                 waste_location=(52, 1),
-                cleaner_location=(52, 128),
+                cleaner_location=(52, 129),
             )
         with pytest.raises(ValueError, match="Site \\(second number in cleaner_location tuple\\)"):
             prepare_evo_wash_parameters(
@@ -304,8 +304,8 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="Parameter arm"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 arm=2,
             )
 
@@ -313,22 +313,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="waste_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_vol=-1.0,
             )
         with pytest.raises(ValueError, match="waste_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_vol=101.0,
             )
         with pytest.raises(ValueError, match="waste_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_vol=1,
             )
 
@@ -336,22 +336,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="waste_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_delay=-1,
             )
         with pytest.raises(ValueError, match="waste_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_delay=1001,
             )
         with pytest.raises(ValueError, match="waste_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 waste_delay=10.0,
             )
 
@@ -359,22 +359,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="cleaner_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_vol=-1.0,
             )
         with pytest.raises(ValueError, match="cleaner_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_vol=101.0,
             )
         with pytest.raises(ValueError, match="cleaner_vol has to be a float"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_vol=1,
             )
 
@@ -382,22 +382,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="cleaner_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_delay=-1,
             )
         with pytest.raises(ValueError, match="cleaner_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_delay=1001,
             )
         with pytest.raises(ValueError, match="cleaner_delay has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 cleaner_delay=10.0,
             )
 
@@ -405,22 +405,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="airgap has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap=-1,
             )
         with pytest.raises(ValueError, match="airgap has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap=101,
             )
         with pytest.raises(ValueError, match="airgap has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap=10.0,
             )
 
@@ -428,22 +428,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="airgap_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap_speed=0,
             )
         with pytest.raises(ValueError, match="airgap_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap_speed=1001,
             )
         with pytest.raises(ValueError, match="airgap_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 airgap_speed=10.0,
             )
 
@@ -451,22 +451,22 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="retract_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 retract_speed=0,
             )
         with pytest.raises(ValueError, match="retract_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 retract_speed=101,
             )
         with pytest.raises(ValueError, match="retract_speed has to be an int"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 retract_speed=10.0,
             )
 
@@ -474,15 +474,15 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="Parameter fastwash"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 fastwash=2,
             )
         with pytest.raises(ValueError, match="Parameter fastwash"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 fastwash=1.0,
             )
 
@@ -490,23 +490,23 @@ class TestEvoWash:
         with pytest.raises(ValueError, match="Parameter low_volume"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 low_volume=2,
             )
         with pytest.raises(ValueError, match="Parameter low_volume"):
             prepare_evo_wash_parameters(
                 tips=[1, 2],
-                waste_location=(52, 1),
-                cleaner_location=(52, 0),
+                waste_location=(52, 2),
+                cleaner_location=(52, 1),
                 low_volume=1.0,
             )
 
         # test complete prepare_evo_wash_parameters() command
         actual = prepare_evo_wash_parameters(
             tips=[1, 2, 3, 4, 5, 6, 7, 8],
-            waste_location=(52, 1),
-            cleaner_location=(52, 0),
+            waste_location=(52, 2),
+            cleaner_location=(52, 1),
         )
         expected = (
             [
@@ -538,8 +538,8 @@ class TestEvoWash:
     def test_evo_wash(self) -> None:
         cmd = evo_wash(
             tips=[1, 2, 3, 4, 5, 6, 7, 8],
-            waste_location=(52, 1),
-            cleaner_location=(52, 0),
+            waste_location=(52, 2),
+            cleaner_location=(52, 1),
         )
         assert cmd == 'B;Wash(255,52,1,52,0,"3.0",500,"4.0",500,10,70,30,1,0,1000,0);'
         return


### PR DESCRIPTION
Technically a breaking change, but it's probably safe to say that noone is using these functions in production yet.

⚠️ Site numbering in the following functions changes to 1-based numbering. The backmost site becomes site=1`.
* `evo_aspirate`
* `evo_dispense`
* `evo_wash`