### PR TITLE
Refactoring of the worklists module

### DIFF
--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -1,6 +1,7 @@
 from . import evotools, liquidhandling
 from .evotools import InvalidOperationError, Labwares, Tip, Worklist
 from .evotools import commands as evo_cmd
+from .evotools import int_to_tip
 from .liquidhandling import Labware, Trough, VolumeOverflowError, VolumeUnderflowError
 from .transform import (
     WellRandomizer,

--- a/robotools/evotools/__init__.py
+++ b/robotools/evotools/__init__.py
@@ -1,3 +1,3 @@
 from robotools.evotools.exceptions import InvalidOperationError
-from robotools.evotools.types import Labwares, Tip
+from robotools.evotools.types import Labwares, Tip, int_to_tip
 from robotools.evotools.worklist import Worklist

--- a/robotools/evotools/commands.py
+++ b/robotools/evotools/commands.py
@@ -13,6 +13,7 @@ __all__ = (
     "evo_make_selection_array",
     "evo_get_selection",
     "evo_aspirate",
+    "evo_dispense",
     "evo_wash",
 )
 

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -1439,7 +1439,7 @@ class TestReagentDistribution:
                 # one excluded well not in the destination range
                 wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=50, exclude_wells=[18, 19, 23])
         with pytest.raises(InvalidOperationError):
-            with caplog.at_level(logging.WARNING, logger="evotools"):
+            with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
                 with Worklist(max_volume=950) as wl:
                     # dispense more than diluter volume
                     wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=1200)
@@ -1627,7 +1627,7 @@ class TestFunctions:
         # fixed to source
         assert "source" == optimize_partition_by(S, D, "source", "No troughs at all")
         assert "source" == optimize_partition_by(S, DT, "source", "Trough destination")
-        with caplog.at_level(logging.WARNING, logger="evotools"):
+        with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
             assert "source" == optimize_partition_by(ST, D, "source", "Trough source")
         assert 'Consider using partition_by="destination"' in caplog.records[0].message
         optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
@@ -1635,7 +1635,7 @@ class TestFunctions:
         # fixed to destination
         optimize_partition_by(S, D, "destination", "No troughs at all") == "destination"
         caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="evotools"):
+        with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
             assert optimize_partition_by(S, DT, "destination", "Trough destination") == "destination"
         assert 'Consider using partition_by="source"' in caplog.records[0].message
         assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -10,10 +10,10 @@ from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Labwares, Tip
 from robotools.evotools.worklist import (
     Worklist,
-    _optimize_partition_by,
-    _partition_by_column,
-    _partition_volume,
-    _prepare_aspirate_dispense_parameters,
+    optimize_partition_by,
+    partition_by_column,
+    partition_volume,
+    prepare_aspirate_dispense_parameters,
 )
 from robotools.liquidhandling.labware import Labware, Trough
 
@@ -26,139 +26,139 @@ class TestWorklist:
 
     def test_parameter_validation(self) -> None:
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
+            prepare_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
+            prepare_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="thisisaveryverylongracklabelthatexceedsthemaximumlength", position=1, volume=15
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="rack label; with semicolon", position=1, volume=15
             )
-        _prepare_aspirate_dispense_parameters(rack_label="valid rack label", position=1, volume=15)
+        prepare_aspirate_dispense_parameters(rack_label="valid rack label", position=1, volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=None, volume=15)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=None, volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position="3", volume=15)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position="3", volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=-1, volume=15)
-        _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=-1, volume=15)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=None)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=None)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="nan")
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="nan")
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=float("nan"))
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=float("nan"))
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=-15.4)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=-15.4)
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="bla")
-        _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="15")
-        _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=20)
-        _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=23.78)
-        _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=np.array(23.4))
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="bla")
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="15")
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=20)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=23.78)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=np.array(23.4))
 
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, liquid_class=None
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, liquid_class="liquid;class"
             )
-        _prepare_aspirate_dispense_parameters(
+        prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, liquid_class="valid liquid class"
         )
 
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=4
         )
         assert tip == 8
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=Tip.T5
         )
         assert tip == 16
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T4, 4)
         )
         assert tip == 8
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=[Tip.T1, 4]
         )
         assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=[1, 4]
         )
         assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=[1, Tip.T4]
         )
         assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = _prepare_aspirate_dispense_parameters(
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, tip=Tip.Any
         )
         assert tip == ""
 
         with pytest.raises(ValueError, match="no Tip.Any elements are allowed"):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T1, Tip.Any)
             )
         with pytest.raises(ValueError, match="tip must be an int between 1 and 8, Tip or Iterable"):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=None)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=None)
         with pytest.raises(ValueError, match="it may only contain int or Tip values"):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, tip=[1, 2.6]
             )
         with pytest.raises(ValueError, match="should be an int between 1 and 8 for _int_to_tip"):
-            _prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=12)
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=12)
 
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, rack_id=None
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, rack_id="invalid;rack"
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough",
                 position=1,
                 volume=15,
                 rack_id="thisisaveryverylongrackthatexceedsthemaximumlength",
             )
-        _prepare_aspirate_dispense_parameters(
+        prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, rack_id="1235464"
         )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, rack_type=None
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, rack_type="invalid;rack type"
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough",
                 position=1,
                 volume=15,
                 rack_type="thisisaveryverylongracktypethatexceedsthemaximumlength",
             )
-        _prepare_aspirate_dispense_parameters(
+        prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, rack_type="valid rack type"
         )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, forced_rack_type=None
             )
         with pytest.raises(ValueError):
-            _prepare_aspirate_dispense_parameters(
+            prepare_aspirate_dispense_parameters(
                 rack_label="WaterTrough", position=1, volume=15, forced_rack_type="invalid;forced rack type"
             )
-        _prepare_aspirate_dispense_parameters(
+        prepare_aspirate_dispense_parameters(
             rack_label="WaterTrough", position=1, volume=15, forced_rack_type="valid forced rack type"
         )
         return
@@ -1094,12 +1094,12 @@ class TestTroughLabwareWorklist:
 
 
 class TestLargeVolumeHandling:
-    def test_partition_volume_helper(self) -> None:
-        assert [] == _partition_volume(0, max_volume=950)
-        assert [550.3] == _partition_volume(550.3, max_volume=950)
-        assert [500 == 500], _partition_volume(1000, max_volume=950)
-        assert [500 == 499], _partition_volume(999, max_volume=950)
-        assert [667 == 667, 666], _partition_volume(2000, max_volume=950)
+    def testpartition_volume_helper(self) -> None:
+        assert [] == partition_volume(0, max_volume=950)
+        assert [550.3] == partition_volume(550.3, max_volume=950)
+        assert [500 == 500], partition_volume(1000, max_volume=950)
+        assert [500 == 499], partition_volume(999, max_volume=950)
+        assert [667 == 667, 666], partition_volume(2000, max_volume=950)
         return
 
     def test_worklist_constructor(self) -> None:
@@ -1167,8 +1167,8 @@ class TestLargeVolumeHandling:
             wl.transfer(source, ["A01", "B01"], destination, ["A01", "B01"], 1000)
         return
 
-    def test_partition_by_columns_source(self) -> None:
-        column_groups = _partition_by_column(
+    def testpartition_by_columns_source(self) -> None:
+        column_groups = partition_by_column(
             ["A01", "B01", "A03", "B03", "C02"],
             ["A01", "B01", "C01", "D01", "E01"],
             [2500, 3500, 1000, 500, 2000],
@@ -1192,8 +1192,8 @@ class TestLargeVolumeHandling:
         )
         return
 
-    def test_partition_by_columns_destination(self) -> None:
-        column_groups = _partition_by_column(
+    def testpartition_by_columns_destination(self) -> None:
+        column_groups = partition_by_column(
             ["A01", "B01", "A03", "B03", "C02"],
             ["A01", "B01", "C02", "D01", "E02"],
             [2500, 3500, 1000, 500, 2000],
@@ -1212,13 +1212,13 @@ class TestLargeVolumeHandling:
         )
         return
 
-    def test_partition_by_columns_sorting(self) -> None:
+    def testpartition_by_columns_sorting(self) -> None:
         # within every column, the wells are supposed to be sorted by row
         # The test source wells are partially sorted (col 1 is in the right order, col 3 in the reverse)
         # The result is expected to always be sorted by row, either in the source (first case) or destination:
 
         # by source
-        column_groups = _partition_by_column(
+        column_groups = partition_by_column(
             ["A01", "B01", "B03", "A03", "C02"],
             ["B01", "A01", "C01", "D01", "E01"],
             [2500, 3500, 1000, 500, 2000],
@@ -1243,7 +1243,7 @@ class TestLargeVolumeHandling:
 
         # by destination
         # (destination wells are across 3 columns; reverse order in col 1, forward order in col 3)
-        column_groups = _partition_by_column(
+        column_groups = partition_by_column(
             ["A01", "B01", "B03", "A03", "C02"],
             ["B01", "A01", "C03", "D03", "E02"],
             [2500, 3500, 1000, 500, 2000],
@@ -1619,25 +1619,25 @@ class TestFunctions:
         # + warn user about inefficient configuration (when user selects to partition by the trough)
 
         # automatic
-        assert "source" == _optimize_partition_by(S, D, "auto", "No troughs at all")
-        assert "source" == _optimize_partition_by(S, DT, "auto", "Trough destination")
-        assert "destination" == _optimize_partition_by(ST, D, "auto", "Trough source")
-        _optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
+        assert "source" == optimize_partition_by(S, D, "auto", "No troughs at all")
+        assert "source" == optimize_partition_by(S, DT, "auto", "Trough destination")
+        assert "destination" == optimize_partition_by(ST, D, "auto", "Trough source")
+        optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
 
         # fixed to source
-        assert "source" == _optimize_partition_by(S, D, "source", "No troughs at all")
-        assert "source" == _optimize_partition_by(S, DT, "source", "Trough destination")
+        assert "source" == optimize_partition_by(S, D, "source", "No troughs at all")
+        assert "source" == optimize_partition_by(S, DT, "source", "Trough destination")
         with caplog.at_level(logging.WARNING, logger="evotools"):
-            assert "source" == _optimize_partition_by(ST, D, "source", "Trough source")
+            assert "source" == optimize_partition_by(ST, D, "source", "Trough source")
         assert 'Consider using partition_by="destination"' in caplog.records[0].message
-        _optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
+        optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
 
         # fixed to destination
-        _optimize_partition_by(S, D, "destination", "No troughs at all") == "destination"
+        optimize_partition_by(S, D, "destination", "No troughs at all") == "destination"
         caplog.clear()
         with caplog.at_level(logging.WARNING, logger="evotools"):
-            assert _optimize_partition_by(S, DT, "destination", "Trough destination") == "destination"
+            assert optimize_partition_by(S, DT, "destination", "Trough destination") == "destination"
         assert 'Consider using partition_by="source"' in caplog.records[0].message
-        assert _optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
-        assert _optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
+        assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
+        assert optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
         return

--- a/robotools/evotools/types.py
+++ b/robotools/evotools/types.py
@@ -4,6 +4,7 @@ import enum
 __all__ = (
     "Labwares",
     "Tip",
+    "int_to_tip",
 )
 
 

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -2,9 +2,8 @@
 """
 import logging
 import math
-import typing
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy
 
@@ -31,7 +30,7 @@ class Worklist(list):
     def __init__(
         self,
         filepath: Optional[Union[str, Path]] = None,
-        max_volume: typing.Union[int, float] = 950,
+        max_volume: Union[int, float] = 950,
         auto_split: bool = True,
     ) -> None:
         """Creates a worklist writer.
@@ -79,7 +78,7 @@ class Worklist(list):
             file.write("\n".join(self))
         return
 
-    def comment(self, comment: typing.Optional[str]) -> None:
+    def comment(self, comment: Optional[str]) -> None:
         """Adds a comment.
 
         Parameters
@@ -174,7 +173,7 @@ class Worklist(list):
         volume: float,
         *,
         liquid_class: str = "",
-        tip: typing.Union[Tip, int, typing.Iterable] = Tip.Any,
+        tip: Union[Tip, int, Iterable] = Tip.Any,
         rack_id: str = "",
         tube_id: str = "",
         rack_type: str = "",
@@ -241,7 +240,7 @@ class Worklist(list):
         volume: float,
         *,
         liquid_class: str = "",
-        tip: typing.Union[Tip, int] = Tip.Any,
+        tip: Union[Tip, int] = Tip.Any,
         rack_id: str = "",
         tube_id: str = "",
         rack_type: str = "",
@@ -305,9 +304,9 @@ class Worklist(list):
     def evo_wash(
         self,
         *,
-        tips: typing.Union[typing.List[Tip], typing.List[int]],
-        waste_location: typing.Tuple[int, int],
-        cleaner_location: typing.Tuple[int, int],
+        tips: Union[List[Tip], List[int]],
+        waste_location: Tuple[int, int],
+        cleaner_location: Tuple[int, int],
         arm: int = 0,
         waste_vol: float = 3.0,
         waste_delay: int = 500,
@@ -382,7 +381,7 @@ class Worklist(list):
         volume: float,
         diti_reuse: int = 1,
         multi_disp: int = 1,
-        exclude_wells: typing.Optional[typing.Iterable[int]] = None,
+        exclude_wells: Optional[Iterable[int]] = None,
         liquid_class: str = "",
         direction: str = "left_to_right",
         src_rack_id: str = "",
@@ -495,10 +494,10 @@ class Worklist(list):
     def aspirate(
         self,
         labware: liquidhandling.Labware,
-        wells: typing.Union[str, typing.Sequence[str], numpy.ndarray],
-        volumes: typing.Union[float, typing.Sequence[float], numpy.ndarray],
+        wells: Union[str, Sequence[str], numpy.ndarray],
+        volumes: Union[float, Sequence[float], numpy.ndarray],
         *,
-        label: typing.Optional[str] = None,
+        label: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Performs aspiration from the provided labware.
@@ -532,14 +531,14 @@ class Worklist(list):
     def evo_aspirate(
         self,
         labware: liquidhandling.Labware,
-        wells: typing.Union[str, typing.List[str]],
-        labware_position: typing.Tuple[int, int],
-        tips: typing.Union[typing.List[Tip], typing.List[int]],
-        volumes: typing.Union[float, typing.List[float]],
+        wells: Union[str, List[str]],
+        labware_position: Tuple[int, int],
+        tips: Union[List[Tip], List[int]],
+        volumes: Union[float, List[float]],
         liquid_class: str,
         *,
         arm: int = 0,
-        label: typing.Optional[str] = None,
+        label: Optional[str] = None,
     ) -> None:
         """Performs aspiration from the provided labware. Is identical to the aspirate command inside the EvoWARE.
         Thus, several wells in a single column can be targeted.
@@ -587,11 +586,11 @@ class Worklist(list):
     def dispense(
         self,
         labware: liquidhandling.Labware,
-        wells: typing.Union[str, typing.Sequence[str], numpy.ndarray],
-        volumes: typing.Union[float, typing.Sequence[float], numpy.ndarray],
+        wells: Union[str, Sequence[str], numpy.ndarray],
+        volumes: Union[float, Sequence[float], numpy.ndarray],
         *,
-        label: typing.Optional[str] = None,
-        compositions: typing.Optional[typing.List[typing.Optional[typing.Dict[str, float]]]] = None,
+        label: Optional[str] = None,
+        compositions: Optional[List[Optional[Dict[str, float]]]] = None,
         **kwargs,
     ) -> None:
         """Performs dispensing into the provided labware.
@@ -627,15 +626,15 @@ class Worklist(list):
     def evo_dispense(
         self,
         labware: liquidhandling.Labware,
-        wells: typing.Union[str, typing.List[str]],
-        labware_position: typing.Tuple[int, int],
-        tips: typing.Union[typing.List[Tip], typing.List[int]],
-        volumes: typing.Union[float, typing.List[float]],
+        wells: Union[str, List[str]],
+        labware_position: Tuple[int, int],
+        tips: Union[List[Tip], List[int]],
+        volumes: Union[float, List[float]],
         liquid_class: str,
         *,
         arm: int = 0,
-        label: typing.Optional[str] = None,
-        compositions: typing.Optional[typing.List[typing.Optional[typing.Dict[str, float]]]] = None,
+        label: Optional[str] = None,
+        compositions: Optional[List[Optional[Dict[str, float]]]] = None,
     ) -> None:
         """Performs dispensation from the provided labware. Is identical to the dispense command inside the EvoWARE.
         Thus, several wells in a single column can be targeted.
@@ -685,12 +684,12 @@ class Worklist(list):
     def transfer(
         self,
         source: liquidhandling.Labware,
-        source_wells: typing.Union[str, typing.Sequence[str], numpy.ndarray],
+        source_wells: Union[str, Sequence[str], numpy.ndarray],
         destination: liquidhandling.Labware,
-        destination_wells: typing.Union[str, typing.Sequence[str], numpy.ndarray],
-        volumes: typing.Union[float, typing.Sequence[float], numpy.ndarray],
+        destination_wells: Union[str, Sequence[str], numpy.ndarray],
+        volumes: Union[float, Sequence[float], numpy.ndarray],
         *,
-        label: typing.Optional[str] = None,
+        label: Optional[str] = None,
         wash_scheme: int = 1,
         partition_by: str = "auto",
         **kwargs,
@@ -806,7 +805,7 @@ class Worklist(list):
         source: liquidhandling.Labware,
         source_column: int,
         destination: liquidhandling.Labware,
-        destination_wells: typing.Union[str, typing.Sequence[str], numpy.ndarray],
+        destination_wells: Union[str, Sequence[str], numpy.ndarray],
         *,
         volume: float,
         diti_reuse: int = 1,

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -1,275 +1,28 @@
 """ Creating worklist files for the Tecan Freedom EVO.
 """
-import collections
 import logging
 import math
 import typing
-import warnings
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy
 
 from robotools.evotools import commands
 from robotools.evotools.exceptions import InvalidOperationError
-from robotools.evotools.types import Tip, int_to_tip
+from robotools.evotools.types import Tip
+from robotools.worklists.utils import (
+    optimize_partition_by,
+    partition_by_column,
+    partition_volume,
+    prepare_aspirate_dispense_parameters,
+)
 
 from .. import liquidhandling
 
 __all__ = ("Worklist",)
 
 logger = logging.getLogger("evotools")
-
-
-def _prepare_aspirate_dispense_parameters(
-    rack_label: str,
-    position: int,
-    volume: float,
-    liquid_class: str = "",
-    tip: typing.Union[Tip, int, collections.abc.Iterable] = Tip.Any,
-    rack_id: str = "",
-    tube_id: str = "",
-    rack_type: str = "",
-    forced_rack_type: str = "",
-    max_volume: typing.Optional[typing.Union[int, float]] = None,
-) -> Tuple[str, int, str, str, Union[Tip, int, collections.abc.Iterable], str, str, str, str]:
-    """Validates and prepares aspirate/dispense parameters.
-
-    Parameters
-    ----------
-    rack_label : str
-        User-defined labware name (max 32 characters)
-    position : int
-        Number of the well
-    volume : float
-        Volume in microliters (will be rounded to 2 decimal places)
-    liquid_class : str, optional
-        Overrides the liquid class for this step (max 32 characters)
-    tip : Tip, int or Iterable of Tip / int, optional
-        Tip that will be selected (Tip, 1-8 or Iterable of the former two)
-    rack_id : str, optional
-        Barcode of the labware (max 32 characters)
-    tube_id : str, optional
-        Barcode of the tube (max 32 characters)
-    rack_type : str, optional
-        Configuration name of the labware (max 32 characters).
-        An error is raised if it missmatches with the underlying worktable.
-    forced_rack_type : str, optional
-        Overrides rack_type from worktable
-    max_volume : int, optional
-        Maximum allowed volume
-
-    Returns
-    -------
-    rack_label : str
-        User-defined labware name (max 32 characters)
-    position : int
-        Number of the well
-    volume : str
-        Volume in microliters (will be rounded to 2 decimal places)
-    liquid_class : str
-        Overrides the liquid class for this step (max 32 characters)
-    tip : Tip, int or Iterable of Tip / int
-        Tip that will be selected (Tip, 1-8 or Iterable of the former two)
-    rack_id : str
-        Barcode of the labware (max 32 characters)
-    tube_id : str
-        Barcode of the tube (max 32 characters)
-    rack_type : str
-        Configuration name of the labware (max 32 characters).
-        An error is raised if it missmatches with the underlying worktable.
-    forced_rack_type : str
-        Overrides rack_type from worktable
-    """
-    # required parameters
-    if rack_label is None:
-        raise ValueError("Missing required parameter: rack_label")
-    if not isinstance(rack_label, str) or len(rack_label) > 32 or ";" in rack_label:
-        raise ValueError(f"Invalid rack_label: {rack_label}")
-
-    if position is None:
-        raise ValueError("Missing required parameter: position")
-    if not isinstance(position, int) or position < 0:
-        raise ValueError(f"Invalid position: {position}")
-
-    if volume is None:
-        raise ValueError("Missing required parameter: volume")
-    try:
-        volume = float(volume)
-    except:
-        raise ValueError(f"Invalid volume: {volume}")
-    if volume < 0 or volume > 7158278 or numpy.isnan(volume):
-        raise ValueError(f"Invalid volume: {volume}")
-    if max_volume is not None and volume > max_volume:
-        raise InvalidOperationError(f"Volume of {volume} exceeds max_volume.")
-
-    # optional parameters
-    if not isinstance(liquid_class, str) or ";" in liquid_class:
-        raise ValueError(f"Invalid liquid_class: {liquid_class}")
-
-    if isinstance(tip, int) and not isinstance(tip, Tip):
-        # User-specified integers from 1-8 need to be converted to Tecan logic
-        tip = int_to_tip(tip)
-
-    if isinstance(tip, collections.abc.Iterable):
-        tips = []
-        for element in tip:
-            if isinstance(element, int) and not isinstance(element, Tip):
-                tips.append(int_to_tip(element))
-            elif isinstance(element, Tip):
-                if element == -1:
-                    raise ValueError(
-                        "When Iterables are used, no Tip.Any elements are allowed. Pass just one Tip.Any instead."
-                    )
-                tips.append(element)
-            else:
-                raise ValueError(
-                    f"If tip is an Iterable, it may only contain int or Tip values, not {type(element)}."
-                )
-        tip = sum(set(tips))
-    elif not isinstance(tip, Tip):
-        raise ValueError(f"tip must be an int between 1 and 8, Tip or Iterable, but was {type(tip)}.")
-
-    if not isinstance(rack_id, str) or len(rack_id) > 32 or ";" in rack_id:
-        raise ValueError(f"Invalid rack_id: {rack_id}")
-    if not isinstance(rack_type, str) or len(rack_type) > 32 or ";" in rack_type:
-        raise ValueError(f"Invalid rack_type: {rack_type}")
-    if not isinstance(forced_rack_type, str) or len(forced_rack_type) > 32 or ";" in forced_rack_type:
-        raise ValueError(f"Invalid forced_rack_type: {forced_rack_type}")
-
-    # apply rounding and corrections for the right string formatting
-    volume_str = f"{numpy.round(volume, decimals=2):.2f}"
-    tip = "" if tip == -1 else tip
-    return rack_label, position, volume_str, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type
-
-
-def _optimize_partition_by(
-    source: liquidhandling.Labware,
-    destination: liquidhandling.Labware,
-    partition_by: str,
-    label: typing.Optional[str] = None,
-) -> str:
-    """Determines optimal partitioning settings.
-
-    Parameters
-    ----------
-    source (Labware): source labware object
-    destination (Labware): destination labware object
-    partition_by : str
-    user-provided partitioning settings
-    label : str
-    label of the operation (optional)
-
-    Returns
-    -------
-    partition_by : str
-        Either 'source' or 'destination'
-    """
-    if not partition_by in {"auto", "source", "destination"}:
-        raise ValueError(f"Invalid partition_by argument: {partition_by}")
-    # automatic partitioning decision
-    if partition_by == "auto":
-        if source.is_trough and not destination.is_trough:
-            partition_by = "destination"
-        else:
-            partition_by = "source"
-    else:
-        # log warnings about potentially inefficient partitioning settings
-        if partition_by == "source" and source.is_trough and not destination.is_trough:
-            logger.warning(
-                f'Partitioning by "source" ({source.name}), which is a Trough while destination ({destination.name}) is not a Trough.'
-                ' This is potentially inefficient. Consider using partition_by="destination".'
-                f" (label={label})"
-            )
-        elif partition_by == "destination" and destination.is_trough and not source.is_trough:
-            logger.warning(
-                f'Partitioning by "destination" ({destination.name}), which is a Trough while source ({source.name}) is not a Trough.'
-                ' This is potentially inefficient. Consider using partition_by="source"'
-                f" (label={label})"
-            )
-    return partition_by
-
-
-def _partition_volume(volume: float, *, max_volume: typing.Union[int, float]) -> typing.List[float]:
-    """Partitions a pipetting volume into zero or more integer-valued volumes that are <= max_volume.
-
-    Parameters
-    ----------
-    volume : float
-        A volume to partition
-    max_volume : int
-        Maximum volume of a pipetting step
-
-    Returns
-    -------
-    volumes : list
-        Partitioned volumes
-    """
-    if volume == 0:
-        return []
-    if volume < max_volume:
-        return [volume]
-    isteps = math.ceil(volume / max_volume)
-    step_volume = math.ceil(volume / isteps)
-    volumes: typing.List[float] = [step_volume] * (isteps - 1)
-    volumes.append(volume - numpy.sum(volumes))
-    return volumes
-
-
-def _partition_by_column(
-    sources: typing.Iterable[str],
-    destinations: typing.Iterable[str],
-    volumes: typing.Iterable[float],
-    partition_by: str,
-) -> List[Tuple[List[str], List[str], List[float]]]:
-    """Partitions sources/destinations/volumes by the source column and sorts within those columns.
-
-    Parameters
-    ----------
-    sources : list
-        The source well ids; same length as destinations and volumes
-    destinations : list
-        The destination well ids; same length as sources and volumes
-    volumes : list
-        The volumes; same length as sources and destinations
-    partition_by : str
-        Either 'source' or 'destination'
-
-    Returns
-    -------
-    column_groups : list
-        A list of (sources, destinations, volumes)
-    """
-    # first partition the wells into columns
-    column_groups_dd: Dict[str, Tuple[List[str], List[str], List[float]]] = collections.defaultdict(
-        lambda: ([], [], [])
-    )
-    for s, d, v in zip(sources, destinations, volumes):
-        if partition_by == "source":
-            group = s[1:]
-        elif partition_by == "destination":
-            group = d[1:]
-        else:
-            raise ValueError(f'Invalid `partition_by` parameter "{partition_by}""')
-        column_groups_dd[group][0].append(s)
-        column_groups_dd[group][1].append(d)
-        column_groups_dd[group][2].append(v)
-    # bring columns in the right order
-    column_groups = [column_groups_dd[col] for col in sorted(column_groups_dd.keys())]
-    # sort the rows within the column
-    for c, (srcs, dsts, vols) in enumerate(column_groups):
-        if partition_by == "source":
-            order = numpy.argsort(srcs)
-        elif partition_by == "destination":
-            order = numpy.argsort(dsts)
-        else:
-            raise ValueError(f'Invalid `partition_by` parameter "{partition_by}""')
-        column_groups[c] = (
-            list(numpy.array(srcs)[order]),
-            list(numpy.array(dsts)[order]),
-            list(numpy.array(vols)[order]),
-        )
-    return column_groups
 
 
 class Worklist(list):
@@ -463,7 +216,7 @@ class Worklist(list):
             tube_id,
             rack_type,
             forced_rack_type,
-        ) = _prepare_aspirate_dispense_parameters(
+        ) = prepare_aspirate_dispense_parameters(
             rack_label,
             position,
             volume,
@@ -531,7 +284,7 @@ class Worklist(list):
             tube_id,
             rack_type,
             forced_rack_type,
-        ) = _prepare_aspirate_dispense_parameters(
+        ) = prepare_aspirate_dispense_parameters(
             rack_label,
             position,
             volume,
@@ -709,7 +462,7 @@ class Worklist(list):
             _,
             src_rack_type,
             _,
-        ) = _prepare_aspirate_dispense_parameters(*src_args, max_volume=self.max_volume)
+        ) = prepare_aspirate_dispense_parameters(*src_args, max_volume=self.max_volume)
 
         dst_args = (dst_rack_label, 1, volume, "", Tip.Any, dst_rack_id, "", dst_rack_type, "")
         (
@@ -722,7 +475,7 @@ class Worklist(list):
             _,
             dst_rack_type,
             _,
-        ) = _prepare_aspirate_dispense_parameters(*dst_args, max_volume=self.max_volume)
+        ) = prepare_aspirate_dispense_parameters(*dst_args, max_volume=self.max_volume)
 
         # automatically decrease multi_disp to support the large volume
         # at the expense of more washing
@@ -988,17 +741,17 @@ class Worklist(list):
         ), f"Number of source/destination/volumes must be equal. They were {lengths}"
 
         # automatic partitioning
-        partition_by = _optimize_partition_by(source, destination, partition_by, label)
+        partition_by = optimize_partition_by(source, destination, partition_by, label)
 
         # the label applies to the entire transfer operation and is not logged at individual aspirate/dispense steps
         self.comment(label)
         nsteps = 0
         lvh_extra = 0
 
-        for srcs, dsts, vols in _partition_by_column(source_wells, destination_wells, volumes, partition_by):
+        for srcs, dsts, vols in partition_by_column(source_wells, destination_wells, volumes, partition_by):
             # make vector of volumes into vector of volume-lists
             vol_lists = [
-                _partition_volume(float(v), max_volume=self.max_volume) if self.auto_split else [v]
+                partition_volume(float(v), max_volume=self.max_volume) if self.auto_split else [v]
                 for v in vols
             ]
             # transfer from this source column until all wells are done

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -21,7 +21,7 @@ from .. import liquidhandling
 
 __all__ = ("Worklist",)
 
-logger = logging.getLogger("evotools")
+logger = logging.getLogger(__name__)
 
 
 class Worklist(list):

--- a/robotools/test_utils.py
+++ b/robotools/test_utils.py
@@ -45,11 +45,11 @@ class TestDilutionPlan:
         plan = DilutionPlan(xmin=0.3, xmax=30, stock=30, R=1, C=3, mode="log", vmax=100, min_transfer=10)
         np.testing.assert_allclose(plan.x, [[30, 3, 0.3]])
         # Reformat instructions for easier equals comparison
-        instructions = [(col, dsteps, pfrom, float(tvols)) for col, dsteps, pfrom, tvols in plan.instructions]
+        instructions = [(col, dsteps, pfrom, list(tvols)) for col, dsteps, pfrom, tvols in plan.instructions]
         assert instructions == [
-            (0, 0, "stock", 100.0),
-            (1, 0, "stock", 10.0),  # The previous column is equal to the stock!
-            (2, 1, 1, 10.0),
+            (0, 0, "stock", [100.0]),
+            (1, 0, "stock", [10.0]),  # The previous column is equal to the stock!
+            (2, 1, 1, [10.0]),
         ]
         plan_s = str(plan)
         lines = plan_s.split("\n")

--- a/robotools/transform.py
+++ b/robotools/transform.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Literal, Tuple
 
 import numpy
 from numpy.typing import ArrayLike
@@ -187,16 +187,22 @@ class WellRotator:
 class WellRandomizer:
     """Helper object to randomize a set of well IDs within a MTP."""
 
-    def __init__(self, original_shape: tuple, random_seed: int, *, mode: str = "full") -> None:
+    def __init__(
+        self,
+        original_shape: Tuple[int, int],
+        random_seed: int,
+        *,
+        mode: Literal["full", "row", "column"] = "full",
+    ) -> None:
         """Create a helper object for randomizing wells.
 
         Parameters
         ----------
-        original_shape : typing.Tuple[int,int]
+        original_shape
             (n_rows, n_cols) of all wells in the source labware
-        random_seed : int
+        random_seed
             Integer for defined and reproduceable randomization
-        mode : str
+        mode
             To switch between `"full"` randomization,
             or randomization only within each `"row"`,
             or randomization only within each `"column"`.

--- a/robotools/utils.py
+++ b/robotools/utils.py
@@ -1,14 +1,13 @@
 """Module with robot-agnostic utilities."""
 import collections
-import typing
-from typing import Callable, Optional
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy
 
 from . import evotools, liquidhandling
 
 
-def get_trough_wells(n: int, trough_wells: typing.Sequence[str]) -> typing.Sequence[str]:
+def get_trough_wells(n: int, trough_wells: Sequence[str]) -> Sequence[str]:
     """Creates a list that re-uses trough wells if needed.
 
     When n > trough.virtual_rows, the available wells are repeated.
@@ -52,7 +51,7 @@ class DilutionPlan:
         C: int,
         stock: float,
         mode: str,
-        vmax: typing.Union[float, typing.Sequence[float]],
+        vmax: Union[float, Sequence[float]],
         min_transfer: float,
     ) -> None:
         """Plans a regularly-spaced dilution series with in very few steps.
@@ -99,7 +98,7 @@ class DilutionPlan:
 
         # collect preparation instructions for each columns
         # (column, dilution steps, prepared from, transfer volumes)
-        instructions: typing.List[typing.Tuple[int, int, typing.Union[int, str], numpy.ndarray]] = []
+        instructions: List[Tuple[int, int, Union[int, str], numpy.ndarray]] = []
         actual_targets = []
 
         # transfer from stock until the volume is too low

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -1,0 +1,273 @@
+"""Utility functions that are relevant for worklist commands."""
+import collections
+import logging
+import math
+import typing
+from typing import Dict, List, Tuple, Union
+
+import numpy
+
+from robotools.evotools.exceptions import InvalidOperationError
+from robotools.evotools.types import Tip, int_to_tip
+
+from .. import liquidhandling
+
+__all__ = (
+    "prepare_aspirate_dispense_parameters",
+    "optimize_partition_by",
+    "partition_volume",
+    "partition_by_column",
+)
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_aspirate_dispense_parameters(
+    rack_label: str,
+    position: int,
+    volume: float,
+    liquid_class: str = "",
+    tip: typing.Union[Tip, int, collections.abc.Iterable] = Tip.Any,
+    rack_id: str = "",
+    tube_id: str = "",
+    rack_type: str = "",
+    forced_rack_type: str = "",
+    max_volume: typing.Optional[typing.Union[int, float]] = None,
+) -> Tuple[str, int, str, str, Union[Tip, int, collections.abc.Iterable], str, str, str, str]:
+    """Validates and prepares aspirate/dispense parameters.
+
+    Parameters
+    ----------
+    rack_label : str
+        User-defined labware name (max 32 characters)
+    position : int
+        Number of the well
+    volume : float
+        Volume in microliters (will be rounded to 2 decimal places)
+    liquid_class : str, optional
+        Overrides the liquid class for this step (max 32 characters)
+    tip : Tip, int or Iterable of Tip / int, optional
+        Tip that will be selected (Tip, 1-8 or Iterable of the former two)
+    rack_id : str, optional
+        Barcode of the labware (max 32 characters)
+    tube_id : str, optional
+        Barcode of the tube (max 32 characters)
+    rack_type : str, optional
+        Configuration name of the labware (max 32 characters).
+        An error is raised if it missmatches with the underlying worktable.
+    forced_rack_type : str, optional
+        Overrides rack_type from worktable
+    max_volume : int, optional
+        Maximum allowed volume
+
+    Returns
+    -------
+    rack_label : str
+        User-defined labware name (max 32 characters)
+    position : int
+        Number of the well
+    volume : str
+        Volume in microliters (will be rounded to 2 decimal places)
+    liquid_class : str
+        Overrides the liquid class for this step (max 32 characters)
+    tip : Tip, int or Iterable of Tip / int
+        Tip that will be selected (Tip, 1-8 or Iterable of the former two)
+    rack_id : str
+        Barcode of the labware (max 32 characters)
+    tube_id : str
+        Barcode of the tube (max 32 characters)
+    rack_type : str
+        Configuration name of the labware (max 32 characters).
+        An error is raised if it missmatches with the underlying worktable.
+    forced_rack_type : str
+        Overrides rack_type from worktable
+    """
+    # required parameters
+    if rack_label is None:
+        raise ValueError("Missing required parameter: rack_label")
+    if not isinstance(rack_label, str) or len(rack_label) > 32 or ";" in rack_label:
+        raise ValueError(f"Invalid rack_label: {rack_label}")
+
+    if position is None:
+        raise ValueError("Missing required parameter: position")
+    if not isinstance(position, int) or position < 0:
+        raise ValueError(f"Invalid position: {position}")
+
+    if volume is None:
+        raise ValueError("Missing required parameter: volume")
+    try:
+        volume = float(volume)
+    except:
+        raise ValueError(f"Invalid volume: {volume}")
+    if volume < 0 or volume > 7158278 or numpy.isnan(volume):
+        raise ValueError(f"Invalid volume: {volume}")
+    if max_volume is not None and volume > max_volume:
+        raise InvalidOperationError(f"Volume of {volume} exceeds max_volume.")
+
+    # optional parameters
+    if not isinstance(liquid_class, str) or ";" in liquid_class:
+        raise ValueError(f"Invalid liquid_class: {liquid_class}")
+
+    if isinstance(tip, int) and not isinstance(tip, Tip):
+        # User-specified integers from 1-8 need to be converted to Tecan logic
+        tip = int_to_tip(tip)
+
+    if isinstance(tip, collections.abc.Iterable):
+        tips = []
+        for element in tip:
+            if isinstance(element, int) and not isinstance(element, Tip):
+                tips.append(int_to_tip(element))
+            elif isinstance(element, Tip):
+                if element == -1:
+                    raise ValueError(
+                        "When Iterables are used, no Tip.Any elements are allowed. Pass just one Tip.Any instead."
+                    )
+                tips.append(element)
+            else:
+                raise ValueError(
+                    f"If tip is an Iterable, it may only contain int or Tip values, not {type(element)}."
+                )
+        tip = sum(set(tips))
+    elif not isinstance(tip, Tip):
+        raise ValueError(f"tip must be an int between 1 and 8, Tip or Iterable, but was {type(tip)}.")
+
+    if not isinstance(rack_id, str) or len(rack_id) > 32 or ";" in rack_id:
+        raise ValueError(f"Invalid rack_id: {rack_id}")
+    if not isinstance(rack_type, str) or len(rack_type) > 32 or ";" in rack_type:
+        raise ValueError(f"Invalid rack_type: {rack_type}")
+    if not isinstance(forced_rack_type, str) or len(forced_rack_type) > 32 or ";" in forced_rack_type:
+        raise ValueError(f"Invalid forced_rack_type: {forced_rack_type}")
+
+    # apply rounding and corrections for the right string formatting
+    volume_str = f"{numpy.round(volume, decimals=2):.2f}"
+    tip = "" if tip == -1 else tip
+    return rack_label, position, volume_str, liquid_class, tip, rack_id, tube_id, rack_type, forced_rack_type
+
+
+def optimize_partition_by(
+    source: liquidhandling.Labware,
+    destination: liquidhandling.Labware,
+    partition_by: str,
+    label: typing.Optional[str] = None,
+) -> str:
+    """Determines optimal partitioning settings.
+
+    Parameters
+    ----------
+    source (Labware): source labware object
+    destination (Labware): destination labware object
+    partition_by : str
+    user-provided partitioning settings
+    label : str
+    label of the operation (optional)
+
+    Returns
+    -------
+    partition_by : str
+        Either 'source' or 'destination'
+    """
+    if not partition_by in {"auto", "source", "destination"}:
+        raise ValueError(f"Invalid partition_by argument: {partition_by}")
+    # automatic partitioning decision
+    if partition_by == "auto":
+        if source.is_trough and not destination.is_trough:
+            partition_by = "destination"
+        else:
+            partition_by = "source"
+    else:
+        # log warnings about potentially inefficient partitioning settings
+        if partition_by == "source" and source.is_trough and not destination.is_trough:
+            logger.warning(
+                f'Partitioning by "source" ({source.name}), which is a Trough while destination ({destination.name}) is not a Trough.'
+                ' This is potentially inefficient. Consider using partition_by="destination".'
+                f" (label={label})"
+            )
+        elif partition_by == "destination" and destination.is_trough and not source.is_trough:
+            logger.warning(
+                f'Partitioning by "destination" ({destination.name}), which is a Trough while source ({source.name}) is not a Trough.'
+                ' This is potentially inefficient. Consider using partition_by="source"'
+                f" (label={label})"
+            )
+    return partition_by
+
+
+def partition_volume(volume: float, *, max_volume: typing.Union[int, float]) -> typing.List[float]:
+    """Partitions a pipetting volume into zero or more integer-valued volumes that are <= max_volume.
+
+    Parameters
+    ----------
+    volume : float
+        A volume to partition
+    max_volume : int
+        Maximum volume of a pipetting step
+
+    Returns
+    -------
+    volumes : list
+        Partitioned volumes
+    """
+    if volume == 0:
+        return []
+    if volume < max_volume:
+        return [volume]
+    isteps = math.ceil(volume / max_volume)
+    step_volume = math.ceil(volume / isteps)
+    volumes: typing.List[float] = [step_volume] * (isteps - 1)
+    volumes.append(volume - numpy.sum(volumes))
+    return volumes
+
+
+def partition_by_column(
+    sources: typing.Iterable[str],
+    destinations: typing.Iterable[str],
+    volumes: typing.Iterable[float],
+    partition_by: str,
+) -> List[Tuple[List[str], List[str], List[float]]]:
+    """Partitions sources/destinations/volumes by the source column and sorts within those columns.
+
+    Parameters
+    ----------
+    sources : list
+        The source well ids; same length as destinations and volumes
+    destinations : list
+        The destination well ids; same length as sources and volumes
+    volumes : list
+        The volumes; same length as sources and destinations
+    partition_by : str
+        Either 'source' or 'destination'
+
+    Returns
+    -------
+    column_groups : list
+        A list of (sources, destinations, volumes)
+    """
+    # first partition the wells into columns
+    column_groups_dd: Dict[str, Tuple[List[str], List[str], List[float]]] = collections.defaultdict(
+        lambda: ([], [], [])
+    )
+    for s, d, v in zip(sources, destinations, volumes):
+        if partition_by == "source":
+            group = s[1:]
+        elif partition_by == "destination":
+            group = d[1:]
+        else:
+            raise ValueError(f'Invalid `partition_by` parameter "{partition_by}""')
+        column_groups_dd[group][0].append(s)
+        column_groups_dd[group][1].append(d)
+        column_groups_dd[group][2].append(v)
+    # bring columns in the right order
+    column_groups = [column_groups_dd[col] for col in sorted(column_groups_dd.keys())]
+    # sort the rows within the column
+    for c, (srcs, dsts, vols) in enumerate(column_groups):
+        if partition_by == "source":
+            order = numpy.argsort(srcs)
+        elif partition_by == "destination":
+            order = numpy.argsort(dsts)
+        else:
+            raise ValueError(f'Invalid `partition_by` parameter "{partition_by}""')
+        column_groups[c] = (
+            list(numpy.array(srcs)[order]),
+            list(numpy.array(dsts)[order]),
+            list(numpy.array(vols)[order]),
+        )
+    return column_groups

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -2,8 +2,7 @@
 import collections
 import logging
 import math
-import typing
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy
 
@@ -27,12 +26,12 @@ def prepare_aspirate_dispense_parameters(
     position: int,
     volume: float,
     liquid_class: str = "",
-    tip: typing.Union[Tip, int, collections.abc.Iterable] = Tip.Any,
+    tip: Union[Tip, int, collections.abc.Iterable] = Tip.Any,
     rack_id: str = "",
     tube_id: str = "",
     rack_type: str = "",
     forced_rack_type: str = "",
-    max_volume: typing.Optional[typing.Union[int, float]] = None,
+    max_volume: Optional[Union[int, float]] = None,
 ) -> Tuple[str, int, str, str, Union[Tip, int, collections.abc.Iterable], str, str, str, str]:
     """Validates and prepares aspirate/dispense parameters.
 
@@ -148,7 +147,7 @@ def optimize_partition_by(
     source: liquidhandling.Labware,
     destination: liquidhandling.Labware,
     partition_by: str,
-    label: typing.Optional[str] = None,
+    label: Optional[str] = None,
 ) -> str:
     """Determines optimal partitioning settings.
 
@@ -191,7 +190,7 @@ def optimize_partition_by(
     return partition_by
 
 
-def partition_volume(volume: float, *, max_volume: typing.Union[int, float]) -> typing.List[float]:
+def partition_volume(volume: float, *, max_volume: Union[int, float]) -> List[float]:
     """Partitions a pipetting volume into zero or more integer-valued volumes that are <= max_volume.
 
     Parameters
@@ -212,15 +211,15 @@ def partition_volume(volume: float, *, max_volume: typing.Union[int, float]) -> 
         return [volume]
     isteps = math.ceil(volume / max_volume)
     step_volume = math.ceil(volume / isteps)
-    volumes: typing.List[float] = [step_volume] * (isteps - 1)
+    volumes: List[float] = [step_volume] * (isteps - 1)
     volumes.append(volume - numpy.sum(volumes))
     return volumes
 
 
 def partition_by_column(
-    sources: typing.Iterable[str],
-    destinations: typing.Iterable[str],
-    volumes: typing.Iterable[float],
+    sources: Iterable[str],
+    destinations: Iterable[str],
+    volumes: Iterable[float],
     partition_by: str,
 ) -> List[Tuple[List[str], List[str], List[float]]]:
     """Partitions sources/destinations/volumes by the source column and sorts within those columns.


### PR DESCRIPTION
* 🚚 Moved utility functions to a new `robotools.worklists.utils` module
* 🚚 Using `from typing` imports everywhere
* 🛡️ Fix a deprecation warning in the tests
* 🚚 Loggers are now named by the name of the module: `evotools` → `robotools.evotools`
* 🚚 Some `__all__` specifications were fixed/updated