### PR TITLE
Move code to align with split-up worklist code & avoid deprecation warnings

### DIFF
--- a/robotools/evotools/__init__.py
+++ b/robotools/evotools/__init__.py
@@ -1,3 +1,3 @@
-from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Labwares, Tip, int_to_tip
 from robotools.evotools.worklist import EvoWorklist, Worklist
+from robotools.worklists.exceptions import InvalidOperationError

--- a/robotools/evotools/commands.py
+++ b/robotools/evotools/commands.py
@@ -3,9 +3,9 @@ from typing import Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
-from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Tip, int_to_tip
 from robotools.evotools.utils import to_hex
+from robotools.worklists.exceptions import InvalidOperationError
 
 from .. import transform
 

--- a/robotools/evotools/exceptions.py
+++ b/robotools/evotools/exceptions.py
@@ -1,7 +1,0 @@
-"""Exceptions related to liquid handling with worklists."""
-
-__all__ = ("InvalidOperationError",)
-
-
-class InvalidOperationError(Exception):
-    pass

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -1,458 +1,48 @@
-import logging
-import os
-import tempfile
-from pathlib import Path
-
 import numpy as np
 import pytest
 
-from robotools.evotools.types import Labwares, Tip
-from robotools.evotools.worklist import Worklist
+from robotools.evotools import EvoWorklist, Labwares
+from robotools.evotools.types import Tip
 from robotools.liquidhandling.labware import Labware, Trough
 from robotools.worklists.exceptions import InvalidOperationError
-from robotools.worklists.utils import (
-    optimize_partition_by,
-    partition_by_column,
-    partition_volume,
-    prepare_aspirate_dispense_parameters,
-)
 
 
-class TestWorklist:
-    def test_context(self) -> None:
-        with Worklist() as worklist:
-            assert worklist is not None
-        return
-
-    def test_parameter_validation(self) -> None:
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="thisisaveryverylongracklabelthatexceedsthemaximumlength", position=1, volume=15
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="rack label; with semicolon", position=1, volume=15
-            )
-        prepare_aspirate_dispense_parameters(rack_label="valid rack label", position=1, volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=None, volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position="3", volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=-1, volume=15)
-        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=None)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="nan")
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=float("nan"))
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=-15.4)
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="bla")
-        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="15")
-        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=20)
-        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=23.78)
-        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=np.array(23.4))
-
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, liquid_class=None
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, liquid_class="liquid;class"
-            )
-        prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, liquid_class="valid liquid class"
-        )
-
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=4
-        )
-        assert tip == 8
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=Tip.T5
-        )
-        assert tip == 16
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T4, 4)
-        )
-        assert tip == 8
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=[Tip.T1, 4]
-        )
-        assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=[1, 4]
-        )
-        assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=[1, Tip.T4]
-        )
-        assert tip == 9
-        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, tip=Tip.Any
-        )
-        assert tip == ""
-
-        with pytest.raises(ValueError, match="no Tip.Any elements are allowed"):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T1, Tip.Any)
-            )
-        with pytest.raises(ValueError, match="tip must be an int between 1 and 8, Tip or Iterable"):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=None)
-        with pytest.raises(ValueError, match="it may only contain int or Tip values"):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, tip=[1, 2.6]
-            )
-        with pytest.raises(ValueError, match="should be an int between 1 and 8 for _int_to_tip"):
-            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=12)
-
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, rack_id=None
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, rack_id="invalid;rack"
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough",
-                position=1,
-                volume=15,
-                rack_id="thisisaveryverylongrackthatexceedsthemaximumlength",
-            )
-        prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, rack_id="1235464"
-        )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, rack_type=None
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, rack_type="invalid;rack type"
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough",
-                position=1,
-                volume=15,
-                rack_type="thisisaveryverylongracktypethatexceedsthemaximumlength",
-            )
-        prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, rack_type="valid rack type"
-        )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, forced_rack_type=None
-            )
-        with pytest.raises(ValueError):
-            prepare_aspirate_dispense_parameters(
-                rack_label="WaterTrough", position=1, volume=15, forced_rack_type="invalid;forced rack type"
-            )
-        prepare_aspirate_dispense_parameters(
-            rack_label="WaterTrough", position=1, volume=15, forced_rack_type="valid forced rack type"
-        )
-        return
-
-    def test_comment(self) -> None:
-        with Worklist() as wl:
-            # empty and None comments should be ignored
-            wl.comment("")
-            wl.comment(None)
-            # this will be the first actual comment
-            wl.comment("This is a simple comment")
-            with pytest.raises(ValueError):
-                wl.comment("It must not contain ; semicolons")
-            wl.comment(
-                """
-            But it may very well be
-            a multiline comment
-            """
-            )
-            exp = ["C;This is a simple comment", "C;But it may very well be", "C;a multiline comment"]
-            assert wl == exp
-        return
-
-    def test_wash(self) -> None:
-        with Worklist() as wl:
-            wl.wash()
-            with pytest.raises(ValueError):
-                wl.wash(scheme=15)
-            with pytest.raises(ValueError):
-                wl.wash(scheme="2")
-            wl.wash(scheme=1)
-            wl.wash(scheme=2)
-            wl.wash(scheme=3)
-            wl.wash(scheme=4)
-            exp = [
-                "W1;",
-                "W1;",
-                "W2;",
-                "W3;",
-                "W4;",
-            ]
-            assert wl == exp
-        return
-
-    def test_decontaminate(self) -> None:
-        with Worklist() as wl:
-            wl.decontaminate()
-            assert wl == ["WD;"]
-        return
-
-    def test_flush(self) -> None:
-        with Worklist() as wl:
-            wl.flush()
-            assert wl == ["F;"]
-        return
-
-    def test_commit(self) -> None:
-        with Worklist() as wl:
-            wl.commit()
-            assert wl == ["B;"]
-        return
-
-    def test_set_diti(self) -> None:
-        with Worklist() as wl:
-            wl.set_diti(diti_index=1)
-            with pytest.raises(InvalidOperationError):
-                wl.set_diti(diti_index=2)
-            wl.commit()
-            wl.set_diti(diti_index=2)
-            assert wl == [
-                "S;1",
-                "B;",
-                "S;2",
-            ]
-        return
-
-    def test_aspirate_single(self) -> None:
-        with Worklist() as wl:
-            wl.aspirate_well("WaterTrough", 1, 200)
-            assert wl[-1] == "A;WaterTrough;;;1;;200.00;;;;"
-            wl.aspirate_well(
-                "WaterTrough", 1, 200, rack_id="12345", rack_type="my_rack_id", tube_id="my_tube_id"
-            )
-            assert wl[-1] == "A;WaterTrough;12345;my_rack_id;1;my_tube_id;200.00;;;;"
-            wl.aspirate_well(
-                "WaterTrough", 1, 200, liquid_class="my_liquid_class", tip=8, forced_rack_type="forced_rack"
-            )
-            assert wl[-1] == "A;WaterTrough;;;1;;200.00;my_liquid_class;;128;forced_rack"
-        return
-
-    def test_dispense_single(self) -> None:
-        with Worklist() as wl:
-            wl.dispense_well("WaterTrough", 1, 200)
-            assert wl[-1] == "D;WaterTrough;;;1;;200.00;;;;"
-            wl.dispense_well(
-                "WaterTrough", 1, 200, rack_id="12345", rack_type="my_rack_id", tube_id="my_tube_id"
-            )
-            assert wl[-1] == "D;WaterTrough;12345;my_rack_id;1;my_tube_id;200.00;;;;"
-            wl.dispense_well(
-                "WaterTrough", 1, 200, liquid_class="my_liquid_class", tip=8, forced_rack_type="forced_rack"
-            )
-            assert wl[-1] == "D;WaterTrough;;;1;;200.00;my_liquid_class;;128;forced_rack"
-        return
-
+class TestEvoWorklist:
     def test_aspirate_systemliquid(self) -> None:
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.aspirate_well(Labwares.SystemLiquid.value, 1, 200)
             assert wl[-1] == "A;Systemliquid;;;1;;200.00;;;;"
         return
 
-    def test_accepts_path(self):
-        fp = Path(tempfile.gettempdir(), os.urandom(24).hex() + ".gwl")
-        try:
-            with Worklist(fp) as wl:
-                wl.comment("Test")
-            assert isinstance(wl._filepath, Path)
-            assert fp.exists()
-        finally:
-            fp.unlink(missing_ok=True)
-        return
+    def test_transfer_volumechecks(self) -> None:
+        source = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        destination = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        with EvoWorklist(max_volume=900, auto_split=False) as wl:
+            with pytest.raises(InvalidOperationError):
+                wl.transfer(source, ["A01", "B01"], destination, ["A01", "B01"], 1000)
 
-    def test_save(self) -> None:
-        tf = tempfile.mktemp() + ".gwl"
-        error = None
-        try:
-            with Worklist() as worklist:
-                worklist.flush()
-                worklist.save(tf)
-                assert os.path.exists(tf)
-                # also check that the file can be overwritten if it exists already
-                worklist.save(tf)
-            assert os.path.exists(tf)
-            with open(tf) as file:
-                lines = file.readlines()
-                assert lines == ["F;"]
-        except Exception as ex:
-            error = ex
-        finally:
-            os.remove(tf)
-        assert os.path.exists(tf == False)
-        if error:
-            raise error
-        return
-
-    def test_autosave(self) -> None:
-        tf = tempfile.mktemp() + ".gwl"
-        error = None
-        try:
-            with Worklist(tf) as worklist:
-                worklist.flush()
-            assert os.path.exists(tf)
-            with open(tf) as file:
-                lines = file.readlines()
-                assert lines == ["F;"]
-        except Exception as ex:
-            error = ex
-        finally:
-            os.remove(tf)
-        assert os.path.exists(tf == False)
-        if error:
-            raise error
-        return
-
-
-class TestStandardLabwareWorklist:
-    def test_aspirate(self) -> None:
-        source = Labware("SourceLW", rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
-        with Worklist() as wl:
-            wl.aspirate(source, ["A01", "A02", "C02"], 50, label=None)
-            wl.aspirate(source, ["A03", "B03", "C03"], [10, 20, 30.5], label="second aspirate")
-            assert wl == [
-                "A;SourceLW;;;1;;50.00;;;;",
-                "A;SourceLW;;;4;;50.00;;;;",
-                "A;SourceLW;;;6;;50.00;;;;",
-                "C;second aspirate",
-                "A;SourceLW;;;7;;10.00;;;;",
-                "A;SourceLW;;;8;;20.00;;;;",
-                "A;SourceLW;;;9;;30.50;;;;",
-            ]
-            np.testing.assert_array_equal(
-                source.volumes,
-                [
-                    [150, 150, 190],
-                    [200, 200, 180],
-                    [200, 150, 169.5],
-                ],
-            )
-            assert len(source.history) == 3
-        return
-
-    def test_aspirate_2d_volumes(self) -> None:
-        source = Labware("SourceLW", rows=2, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
-        with Worklist() as wl:
-            wl.aspirate(
-                source,
-                source.wells[:, :2],
-                volumes=np.array(
-                    [
-                        [20, 30],
-                        [15.3, 17.53],
-                    ]
-                ),
-            )
-            assert wl == [
-                "A;SourceLW;;;1;;20.00;;;;",
-                "A;SourceLW;;;2;;15.30;;;;",
-                "A;SourceLW;;;3;;30.00;;;;",
-                "A;SourceLW;;;4;;17.53;;;;",
-            ]
-            np.testing.assert_array_equal(source.volumes, [[180, 170, 200], [200 - 15.3, 200 - 17.53, 200]])
-            assert len(source.history) == 2
-        return
-
-    def test_dispense(self) -> None:
-        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
-        with Worklist() as wl:
-            wl.dispense(destination, ["A01", "A02", "A03"], 150, label=None)
-            wl.dispense(destination, ["B01", "B02", "B03"], [10, 20, 30.5], label="second dispense")
-            assert wl == [
-                "D;DestinationLW;;;1;;150.00;;;;",
-                "D;DestinationLW;;;3;;150.00;;;;",
-                "D;DestinationLW;;;5;;150.00;;;;",
-                "C;second dispense",
-                "D;DestinationLW;;;2;;10.00;;;;",
-                "D;DestinationLW;;;4;;20.00;;;;",
-                "D;DestinationLW;;;6;;30.50;;;;",
-            ]
-            np.testing.assert_array_equal(
-                destination.volumes,
-                [
-                    [150, 150, 150],
-                    [10, 20, 30.5],
-                ],
-            )
-            assert len(destination.history) == 3
-        return
-
-    def test_dispense_2d_volumes(self) -> None:
-        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
-        with Worklist() as wl:
-            wl.dispense(
-                destination,
-                destination.wells[:, :2],
-                volumes=np.array(
-                    [
-                        [20, 30],
-                        [15.3, 17.53],
-                    ]
-                ),
-            )
-            assert wl == [
-                "D;DestinationLW;;;1;;20.00;;;;",
-                "D;DestinationLW;;;2;;15.30;;;;",
-                "D;DestinationLW;;;3;;30.00;;;;",
-                "D;DestinationLW;;;4;;17.53;;;;",
-            ]
-            np.testing.assert_array_equal(destination.volumes, [[20, 30, 0], [15.3, 17.53, 0]])
-            assert len(destination.history) == 2
-        return
-
-    def test_skip_zero_volumes(self) -> None:
-        source = Labware("SourceLW", rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
-        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
-        with Worklist() as wl:
-            wl.aspirate(source, ["A03", "B03", "C03"], [10, 0, 30.5])
-            wl.dispense(destination, ["B01", "B02", "B03"], [10, 0, 30.5])
-            assert wl == [
-                "A;SourceLW;;;7;;10.00;;;;",
-                "A;SourceLW;;;9;;30.50;;;;",
-                "D;DestinationLW;;;2;;10.00;;;;",
-                "D;DestinationLW;;;6;;30.50;;;;",
-            ]
-            np.testing.assert_array_equal(
-                source.volumes,
-                [
-                    [200, 200, 190],
-                    [200, 200, 200],
-                    [200, 200, 169.5],
-                ],
-            )
-            np.testing.assert_array_equal(
-                destination.volumes,
-                [
-                    [0, 0, 0],
-                    [10, 0, 30.5],
-                ],
-            )
-            assert len(destination.history) == 2
+        with EvoWorklist(max_volume=1200) as wl:
+            wl.transfer(source, ["A01", "B01"], destination, ["A01", "B01"], 1000)
         return
 
     def test_transfer_2d_volumes(self) -> None:
         A = Labware("A", 2, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 2, 4, min_volume=50, max_volume=250)
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.transfer(
                 A,
                 A.wells[:, :2],
@@ -502,7 +92,7 @@ class TestStandardLabwareWorklist:
     def test_transfer_2d_volumes_no_wash(self) -> None:
         A = Labware("A", 2, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 2, 4, min_volume=50, max_volume=250)
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.transfer(
                 A,
                 A.wells[:, :2],
@@ -548,7 +138,7 @@ class TestStandardLabwareWorklist:
         A = Labware("A", 3, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
         wells = ["A01", "B01"]
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, wells, B, wells, 50, label="first transfer")
             np.testing.assert_array_equal(
                 A.volumes,
@@ -607,7 +197,7 @@ class TestStandardLabwareWorklist:
         A = Labware("A", 3, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
         wells = A.wells[:, :2]
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, wells, B, wells, 50)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -653,7 +243,7 @@ class TestStandardLabwareWorklist:
     def test_transfer_one_many(self) -> None:
         A = Labware("A", 3, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, "A01", B, ["B01", "B02", "B03"], 25)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -717,7 +307,7 @@ class TestStandardLabwareWorklist:
     def test_transfer_many_one(self) -> None:
         A = Labware("A", 3, 4, min_volume=50, max_volume=250, initial_volumes=200)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, ["A01", "A02", "A03"], B, "B01", 25)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -751,151 +341,10 @@ class TestStandardLabwareWorklist:
             assert len(B.history) == 2
         return
 
-    def test_tip_selection(self) -> None:
-        A = Labware("A", 3, 4, min_volume=10, max_volume=250, initial_volumes=100)
-        with Worklist() as wl:
-            wl.aspirate(A, "A01", 10, tip=1)
-            wl.aspirate(A, "A01", 10, tip=2)
-            wl.aspirate(A, "A01", 10, tip=3)
-            wl.aspirate(A, "A01", 10, tip=4)
-            wl.aspirate(A, "A01", 10, tip=5)
-            wl.aspirate(A, "A01", 10, tip=6)
-            wl.aspirate(A, "A01", 10, tip=7)
-            wl.aspirate(A, "A01", 10, tip=8)
-            wl.dispense(A, "B01", 10, tip=Tip.T1)
-            wl.dispense(A, "B02", 10, tip=Tip.T2)
-            wl.dispense(A, "B03", 10, tip=Tip.T3)
-            wl.dispense(A, "B04", 10, tip=Tip.T4)
-            wl.dispense(A, "B04", 10, tip=Tip.T5)
-            wl.dispense(A, "B04", 10, tip=Tip.T6)
-            wl.dispense(A, "B04", 10, tip=Tip.T7)
-            wl.dispense(A, "B04", 10, tip=Tip.T8)
-            assert wl == [
-                "A;A;;;1;;10.00;;;1;",
-                "A;A;;;1;;10.00;;;2;",
-                "A;A;;;1;;10.00;;;4;",
-                "A;A;;;1;;10.00;;;8;",
-                "A;A;;;1;;10.00;;;16;",
-                "A;A;;;1;;10.00;;;32;",
-                "A;A;;;1;;10.00;;;64;",
-                "A;A;;;1;;10.00;;;128;",
-                "D;A;;;2;;10.00;;;1;",
-                "D;A;;;5;;10.00;;;2;",
-                "D;A;;;8;;10.00;;;4;",
-                "D;A;;;11;;10.00;;;8;",
-                "D;A;;;11;;10.00;;;16;",
-                "D;A;;;11;;10.00;;;32;",
-                "D;A;;;11;;10.00;;;64;",
-                "D;A;;;11;;10.00;;;128;",
-            ]
-        return
-
-    def test_tip_mask(self) -> None:
-        A = Labware("A", 3, 4, min_volume=10, max_volume=250)
-
-        # Only allow three specific tips to be used...
-        tips = [
-            Tip.T1,  # 1 +
-            Tip.T4,  # 8 +
-            Tip.T7,  # 64
-            # The sum of tips is = 73
-        ]
-        with Worklist() as wl:
-            wl.dispense(A, "A01", 10, tip=tips)
-        assert wl[-1] == "D;A;;;1;;10.00;;;73;"
-        pass
-
-    def test_history_condensation(self) -> None:
-        A = Labware("A", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
-        B = Labware("B", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
-
-        with Worklist() as wl:
-            wl.transfer(A, ["A01", "B01", "C02"], B, ["A01", "B02", "C01"], [900, 100, 900], label="transfer")
-
-        assert len(A.history) == 2
-        assert A.history[-1][0] == "transfer"
-        np.testing.assert_array_equal(
-            A.history[-1][1],
-            [
-                [1500 - 900, 1500],
-                [1500 - 100, 1500],
-                [1500, 1500 - 900],
-            ],
-        )
-
-        assert len(B.history) == 2
-        assert B.history[-1][0] == "transfer"
-        np.testing.assert_array_equal(
-            B.history[-1][1],
-            [
-                [1500 + 900, 1500],
-                [1500, 1500 + 100],
-                [1500 + 900, 1500],
-            ],
-        )
-        return
-
-    def test_history_condensation_within_labware(self) -> None:
-        A = Labware("A", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
-
-        with Worklist() as wl:
-            wl.transfer(A, ["A01", "B01", "C02"], A, ["A01", "B02", "C01"], [900, 100, 900], label="mix")
-
-        assert len(A.history) == 2
-        assert A.history[-1][0] == "mix"
-        np.testing.assert_array_equal(
-            A.history[-1][1],
-            [
-                [1500 - 900 + 900, 1500],
-                [1500 - 100, 1500 + 100],
-                [1500 + 900, 1500 - 900],
-            ],
-        )
-        return
-
-
-class TestTroughLabwareWorklist:
-    def test_aspirate(self) -> None:
-        source = Trough(
-            "SourceLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200
-        )
-        with Worklist() as wl:
-            wl.aspirate(source, ["A01", "A02", "C02"], 50)
-            wl.aspirate(source, ["A01", "A02", "C02"], [1, 2, 3])
-            assert wl == [
-                "A;SourceLW;;;1;;50.00;;;;",
-                "A;SourceLW;;;4;;50.00;;;;",
-                "A;SourceLW;;;6;;50.00;;;;",
-                "A;SourceLW;;;1;;1.00;;;;",
-                "A;SourceLW;;;4;;2.00;;;;",
-                "A;SourceLW;;;6;;3.00;;;;",
-            ]
-            np.testing.assert_array_equal(source.volumes, [[149, 95, 200]])
-            assert len(source.history) == 3
-        return
-
-    def test_dispense(self) -> None:
-        destination = Trough("DestinationLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200)
-        with Worklist() as wl:
-            wl.dispense(destination, ["A01", "A02", "A03", "B01"], 50)
-            wl.dispense(destination, ["A01", "A02", "C02"], [1, 2, 3])
-            assert wl == [
-                "D;DestinationLW;;;1;;50.00;;;;",
-                "D;DestinationLW;;;4;;50.00;;;;",
-                "D;DestinationLW;;;7;;50.00;;;;",
-                "D;DestinationLW;;;2;;50.00;;;;",
-                "D;DestinationLW;;;1;;1.00;;;;",
-                "D;DestinationLW;;;4;;2.00;;;;",
-                "D;DestinationLW;;;6;;3.00;;;;",
-            ]
-            np.testing.assert_array_equal(destination.volumes, [[101, 55, 50]])
-            assert len(destination.history) == 3
-        return
-
     def test_transfer_many_many(self) -> None:
         A = Trough("A", 3, 4, min_volume=50, max_volume=2500, initial_volumes=2000)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, ["A01", "B01"], B, ["A01", "B01"], 50)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -949,7 +398,7 @@ class TestTroughLabwareWorklist:
     def test_transfer_one_many(self) -> None:
         A = Trough("A", 3, 4, min_volume=50, max_volume=2500, initial_volumes=2000)
         B = Labware("B", 3, 4, min_volume=50, max_volume=250)
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, "A01", B, ["B01", "B02", "B03"], 25)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -1022,7 +471,7 @@ class TestTroughLabwareWorklist:
     def test_transfer_many_one(self) -> None:
         A = Trough("A", 3, 4, min_volume=50, max_volume=2500, initial_volumes=[2000, 1500, 1000, 500])
         B = Labware("B", 3, 4, min_volume=10, max_volume=250, initial_volumes=100)
-        with Worklist() as worklist:
+        with EvoWorklist() as worklist:
             worklist.transfer(A, ["A01", "A02", "A03"], B, "B01", 25)
             np.testing.assert_array_equal(
                 A.volumes,
@@ -1092,185 +541,60 @@ class TestTroughLabwareWorklist:
             assert len(B.history) == 3
         return
 
+    def test_history_condensation(self) -> None:
+        A = Labware("A", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
+        B = Labware("B", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
+
+        with EvoWorklist() as wl:
+            wl.transfer(A, ["A01", "B01", "C02"], B, ["A01", "B02", "C01"], [900, 100, 900], label="transfer")
+
+        assert len(A.history) == 2
+        assert A.history[-1][0] == "transfer"
+        np.testing.assert_array_equal(
+            A.history[-1][1],
+            [
+                [1500 - 900, 1500],
+                [1500 - 100, 1500],
+                [1500, 1500 - 900],
+            ],
+        )
+
+        assert len(B.history) == 2
+        assert B.history[-1][0] == "transfer"
+        np.testing.assert_array_equal(
+            B.history[-1][1],
+            [
+                [1500 + 900, 1500],
+                [1500, 1500 + 100],
+                [1500 + 900, 1500],
+            ],
+        )
+        return
+
+    def test_history_condensation_within_labware(self) -> None:
+        A = Labware("A", 3, 2, min_volume=300, max_volume=4600, initial_volumes=1500)
+
+        with EvoWorklist() as wl:
+            wl.transfer(A, ["A01", "B01", "C02"], A, ["A01", "B02", "C01"], [900, 100, 900], label="mix")
+
+        assert len(A.history) == 2
+        assert A.history[-1][0] == "mix"
+        np.testing.assert_array_equal(
+            A.history[-1][1],
+            [
+                [1500 - 900 + 900, 1500],
+                [1500 - 100, 1500 + 100],
+                [1500 + 900, 1500 - 900],
+            ],
+        )
+        return
+
 
 class TestLargeVolumeHandling:
-    def testpartition_volume_helper(self) -> None:
-        assert [] == partition_volume(0, max_volume=950)
-        assert [550.3] == partition_volume(550.3, max_volume=950)
-        assert [500 == 500], partition_volume(1000, max_volume=950)
-        assert [500 == 499], partition_volume(999, max_volume=950)
-        assert [667 == 667, 666], partition_volume(2000, max_volume=950)
-        return
-
-    def test_worklist_constructor(self) -> None:
-        with pytest.raises(ValueError):
-            with Worklist(max_volume=None) as wl:
-                pass
-        with Worklist(max_volume=800, auto_split=True) as wl:
-            assert wl.max_volume == 800
-            assert wl.auto_split == True
-        with Worklist(max_volume=800, auto_split=False) as wl:
-            assert wl.max_volume == 800
-            assert wl.auto_split == False
-        return
-
-    def test_max_volume_checking(self) -> None:
-        source = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
-        destination = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
-        with Worklist(max_volume=900, auto_split=False) as wl:
-            with pytest.raises(InvalidOperationError):
-                wl.aspirate_well("WaterTrough", 1, 1000)
-            with pytest.raises(InvalidOperationError):
-                wl.dispense_well("WaterTrough", 1, 1000)
-            with pytest.raises(InvalidOperationError):
-                wl.aspirate(source, ["A01", "A02", "C02"], 1000)
-            with pytest.raises(InvalidOperationError):
-                wl.dispense(source, ["A01", "A02", "C02"], 1000)
-            with pytest.raises(InvalidOperationError):
-                wl.transfer(source, ["A01", "B01"], destination, ["A01", "B01"], 1000)
-
-        source = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
-        destination = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
-        with Worklist(max_volume=1200) as wl:
-            wl.aspirate_well("WaterTrough", 1, 1000)
-            wl.dispense_well("WaterTrough", 1, 1000)
-            wl.aspirate(source, ["A01", "A02", "C02"], 1000)
-            wl.dispense(source, ["A01", "A02", "C02"], 1000)
-            wl.transfer(source, ["A01", "B01"], destination, ["A01", "B01"], 1000)
-        return
-
-    def testpartition_by_columns_source(self) -> None:
-        column_groups = partition_by_column(
-            ["A01", "B01", "A03", "B03", "C02"],
-            ["A01", "B01", "C01", "D01", "E01"],
-            [2500, 3500, 1000, 500, 2000],
-            partition_by="source",
-        )
-        assert len(column_groups) == 3
-        assert column_groups[0] == (
-            ["A01", "B01"],
-            ["A01", "B01"],
-            [2500, 3500],
-        )
-        assert column_groups[1] == (
-            ["C02"],
-            ["E01"],
-            [2000],
-        )
-        assert column_groups[2] == (
-            ["A03", "B03"],
-            ["C01", "D01"],
-            [1000, 500],
-        )
-        return
-
-    def testpartition_by_columns_destination(self) -> None:
-        column_groups = partition_by_column(
-            ["A01", "B01", "A03", "B03", "C02"],
-            ["A01", "B01", "C02", "D01", "E02"],
-            [2500, 3500, 1000, 500, 2000],
-            partition_by="destination",
-        )
-        assert len(column_groups) == 2
-        assert column_groups[0] == (
-            ["A01", "B01", "B03"],
-            ["A01", "B01", "D01"],
-            [2500, 3500, 500],
-        )
-        assert column_groups[1] == (
-            ["A03", "C02"],
-            ["C02", "E02"],
-            [1000, 2000],
-        )
-        return
-
-    def testpartition_by_columns_sorting(self) -> None:
-        # within every column, the wells are supposed to be sorted by row
-        # The test source wells are partially sorted (col 1 is in the right order, col 3 in the reverse)
-        # The result is expected to always be sorted by row, either in the source (first case) or destination:
-
-        # by source
-        column_groups = partition_by_column(
-            ["A01", "B01", "B03", "A03", "C02"],
-            ["B01", "A01", "C01", "D01", "E01"],
-            [2500, 3500, 1000, 500, 2000],
-            partition_by="source",
-        )
-        assert len(column_groups) == 3
-        assert column_groups[0] == (
-            ["A01", "B01"],
-            ["B01", "A01"],
-            [2500, 3500],
-        )
-        assert column_groups[1] == (
-            ["C02"],
-            ["E01"],
-            [2000],
-        )
-        assert column_groups[2] == (
-            ["A03", "B03"],
-            ["D01", "C01"],
-            [500, 1000],
-        )
-
-        # by destination
-        # (destination wells are across 3 columns; reverse order in col 1, forward order in col 3)
-        column_groups = partition_by_column(
-            ["A01", "B01", "B03", "A03", "C02"],
-            ["B01", "A01", "C03", "D03", "E02"],
-            [2500, 3500, 1000, 500, 2000],
-            partition_by="destination",
-        )
-        assert len(column_groups) == 3
-        assert column_groups[0] == (
-            ["B01", "A01"],
-            ["A01", "B01"],
-            [3500, 2500],
-        )
-        assert column_groups[1] == (
-            ["C02"],
-            ["E02"],
-            [2000],
-        )
-        assert column_groups[2] == (
-            ["B03", "A03"],
-            ["C03", "D03"],
-            [1000, 500],
-        )
-        return
-
     def test_single_split(self) -> None:
         src = Labware("A", 3, 2, min_volume=1000, max_volume=25000, initial_volumes=12000)
         dst = Labware("B", 3, 2, min_volume=1000, max_volume=25000)
-        with Worklist(auto_split=True) as wl:
+        with EvoWorklist(auto_split=True) as wl:
             wl.transfer(src, "A01", dst, "A01", 2000, label="Transfer more than 2x the max")
             assert wl == [
                 "C;Transfer more than 2x the max",
@@ -1311,7 +635,7 @@ class TestLargeVolumeHandling:
     def test_column_split(self) -> None:
         src = Labware("A", 4, 2, min_volume=1000, max_volume=25000, initial_volumes=12000)
         dst = Labware("B", 4, 2, min_volume=1000, max_volume=25000)
-        with Worklist(auto_split=True) as wl:
+        with EvoWorklist(auto_split=True) as wl:
             wl.transfer(
                 src, ["A01", "B01", "D01", "C01"], dst, ["A01", "B01", "D01", "C01"], [1500, 250, 0, 1200]
             )
@@ -1358,7 +682,7 @@ class TestLargeVolumeHandling:
     def test_block_split(self) -> None:
         src = Labware("A", 3, 2, min_volume=1000, max_volume=25000, initial_volumes=12000)
         dst = Labware("B", 3, 2, min_volume=1000, max_volume=25000)
-        with Worklist(auto_split=True) as wl:
+        with EvoWorklist(auto_split=True) as wl:
             wl.transfer(
                 # A01, B01, A02, B02
                 src,
@@ -1430,224 +754,11 @@ class TestLargeVolumeHandling:
         return
 
 
-class TestReagentDistribution:
-    def test_parameter_validation(self, caplog) -> None:
-        with Worklist() as wl:
-            with pytest.raises(ValueError):
-                wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=50, direction="invalid")
-            with pytest.raises(ValueError):
-                # one excluded well not in the destination range
-                wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=50, exclude_wells=[18, 19, 23])
-        with pytest.raises(InvalidOperationError):
-            with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
-                with Worklist(max_volume=950) as wl:
-                    # dispense more than diluter volume
-                    wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=1200)
-            assert "account for a large dispense" in caplog.records[0].message
-        return
-
-    def test_default_parameterization(self) -> None:
-        with Worklist() as wl:
-            wl.reagent_distribution("S1", 1, 20, "D1", 2, 21, volume=50)
-        assert wl[0] == "R;S1;;;1;20;D1;;;2;21;50;;1;1;0"
-        return
-
-    def test_full_parameterization(self) -> None:
-        with Worklist() as wl:
-            wl.reagent_distribution(
-                "S1",
-                1,
-                20,
-                "D1",
-                2,
-                21,
-                volume=50,
-                diti_reuse=2,
-                multi_disp=3,
-                exclude_wells=[2, 4, 8],
-                liquid_class="TestLC",
-                direction="right_to_left",
-                src_rack_type="MP3Pos",
-                dst_rack_type="MP4Pos",
-                src_rack_id="S1234",
-                dst_rack_id="D1234",
-            )
-        assert wl[0] == "R;S1;S1234;MP3Pos;1;20;D1;D1234;MP4Pos;2;21;50;TestLC;2;3;1;2;4;8"
-        return
-
-    def test_large_volume_multi_disp_adaption(self) -> None:
-        with Worklist() as wl:
-            wl.reagent_distribution(
-                "S1",
-                1,
-                8,
-                "D1",
-                1,
-                96,
-                volume=400,
-                multi_disp=6,
-            )
-        assert wl[0] == "R;S1;;;1;8;D1;;;1;96;400;;1;2;0"
-        return
-
-    def test_oo_parameter_validation(self) -> None:
-        with Worklist() as wl:
-            src = Labware("NotATrough", 6, 2, min_volume=20, max_volume=1000)
-            dst = Labware("48deep", 6, 8, min_volume=50, max_volume=4000)
-            with pytest.raises(ValueError):
-                wl.distribute(src, 0, dst, dst.wells[:, :3], volume=50)
-        with Worklist(max_volume=950) as wl:
-            src = Trough("Water", 8, 2, min_volume=20, max_volume=1000)
-            dst = Labware("48deep", 6, 8, min_volume=50, max_volume=4000)
-            with pytest.raises(InvalidOperationError):
-                wl.distribute(src, 0, dst, dst.wells[:, :3], volume=1200)
-        return
-
-    def test_oo_example_1(self) -> None:
-        src = Trough(
-            "T3",
-            8,
-            1,
-            min_volume=20,
-            max_volume=100 * 1000,
-            initial_volumes=100 * 1000,
-        )
-        dst = Labware("MTP-96-3", 8, 12, min_volume=20, max_volume=300)
-        with Worklist() as wl:
-            all_dst_wells = set(dst.wells.flatten("F"))
-            skip_wells = set("C04,C07,E09,F06,B11".split(","))
-            dst_wells = list(all_dst_wells.difference(skip_wells))
-            wl.distribute(
-                src,
-                0,
-                dst,
-                dst_wells,
-                volume=100,
-                liquid_class="Water",
-                diti_reuse=1,
-                multi_disp=6,
-                direction="left_to_right",
-                src_rack_type="Trough 100ml",
-                dst_rack_type="96 Well Microplate",
-                label="Test Label",
-            )
-        assert wl[0] == "C;Test Label"
-        assert (
-            wl[1] == "R;T3;;Trough 100ml;1;8;MTP-96-3;;96 Well Microplate;1;96;100;Water;1;6;0;27;46;51;69;82"
-        )
-        assert src.volumes[0 == 0], 100 * 1000 - 91 * 100
-        dst_exp = np.ones_like(dst.volumes) * 100
-        dst_exp[dst.indices["C04"]] = 0
-        dst_exp[dst.indices["C07"]] = 0
-        dst_exp[dst.indices["E09"]] = 0
-        dst_exp[dst.indices["F06"]] = 0
-        dst_exp[dst.indices["B11"]] = 0
-        np.testing.assert_array_equal(dst.volumes, dst_exp)
-        return
-
-    def test_oo_example_2(self) -> None:
-        src = Trough(
-            "T2",
-            8,
-            1,
-            min_volume=20,
-            max_volume=100 * 1000,
-            initial_volumes=100 * 1000,
-        )
-        dst = Labware("MTP-96-2", 8, 12, min_volume=20, max_volume=300)
-        with Worklist() as wl:
-            wl.distribute(
-                src,
-                0,
-                dst,
-                dst.wells,
-                volume=100,
-                liquid_class="Water",
-                diti_reuse=2,
-                multi_disp=5,
-                direction="left_to_right",
-                src_rack_type="Trough 100ml",
-                dst_rack_type="96 Well Microplate",
-                label="Test Label",
-            )
-        assert wl[0] == "C;Test Label"
-        assert wl[1] == "R;T2;;Trough 100ml;1;8;MTP-96-2;;96 Well Microplate;1;96;100;Water;2;5;0"
-        assert src.volumes[0 == 0], 100 * 1000 - 96 * 100
-        np.testing.assert_array_equal(dst.volumes, np.ones_like(dst.volumes) * 100)
-        return
-
-    def test_oo_block_from_right(self) -> None:
-        src = Trough(
-            "Water",
-            8,
-            1,
-            min_volume=20,
-            max_volume=100 * 1000,
-            initial_volumes=100 * 1000,
-        )
-        dst = Labware("96mtp", 8, 12, min_volume=20, max_volume=300)
-        with Worklist() as wl:
-            wl.distribute(
-                src,
-                0,
-                dst,
-                dst.wells[1:4, 2:7],
-                volume=50,
-                liquid_class="TestLC",
-                diti_reuse=10,
-                multi_disp=5,
-                direction="right_to_left",
-                label="Test Label",
-            )
-        assert wl[0] == "C;Test Label"
-        skip_pos = ";21;22;23;24;25;29;30;31;32;33;37;38;39;40;41;45;46;47;48;49"
-        assert wl[1] == f"R;Water;;;1;8;96mtp;;;18;52;50;TestLC;10;5;1{skip_pos}"
-        assert src.volumes[0 == 0], 100 * 1000 - 15 * 50
-        assert np.all(dst.volumes[1:4, 2:7] == 50)
-        return
-
-
-class TestFunctions:
-    def test_automatic_partitioning(self, caplog) -> None:
-        S = Labware("S", 8, 2, min_volume=5000, max_volume=250 * 1000)
-        D = Labware("D", 8, 2, min_volume=5000, max_volume=250 * 1000)
-        ST = Trough("ST", 8, 2, min_volume=5000, max_volume=250 * 1000)
-        DT = Trough("DT", 8, 2, min_volume=5000, max_volume=250 * 1000)
-
-        # Expected behaviors:
-        # + always keep settings other than 'auto'
-        # + warn user about inefficient configuration (when user selects to partition by the trough)
-
-        # automatic
-        assert "source" == optimize_partition_by(S, D, "auto", "No troughs at all")
-        assert "source" == optimize_partition_by(S, DT, "auto", "Trough destination")
-        assert "destination" == optimize_partition_by(ST, D, "auto", "Trough source")
-        optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
-
-        # fixed to source
-        assert "source" == optimize_partition_by(S, D, "source", "No troughs at all")
-        assert "source" == optimize_partition_by(S, DT, "source", "Trough destination")
-        with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
-            assert "source" == optimize_partition_by(ST, D, "source", "Trough source")
-        assert 'Consider using partition_by="destination"' in caplog.records[0].message
-        optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
-
-        # fixed to destination
-        optimize_partition_by(S, D, "destination", "No troughs at all") == "destination"
-        caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
-            assert optimize_partition_by(S, DT, "destination", "Trough destination") == "destination"
-        assert 'Consider using partition_by="source"' in caplog.records[0].message
-        assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
-        assert optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
-        return
-
-
 class TestEvoCommands:
     def test_evo_aspirate(self) -> None:
         lw = Labware("A", 4, 5, min_volume=10, max_volume=100)
         lw.add("A01", 50)
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.evo_aspirate(
                 lw,
                 "A01",
@@ -1663,7 +774,7 @@ class TestEvoCommands:
 
     def test_evo_dispense(self) -> None:
         lw = Labware("A", 4, 5, min_volume=10, max_volume=100)
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.evo_dispense(
                 lw,
                 "A01",
@@ -1678,7 +789,7 @@ class TestEvoCommands:
         pass
 
     def test_evo_wash(self) -> None:
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.evo_wash(
                 tips=[Tip.T1, Tip.T5],
                 waste_location=(40, 2),

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -1641,3 +1641,49 @@ class TestFunctions:
         assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
         assert optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
         return
+
+
+class TestEvoCommands:
+    def test_evo_aspirate(self) -> None:
+        lw = Labware("A", 4, 5, min_volume=10, max_volume=100)
+        lw.add("A01", 50)
+        with Worklist() as wl:
+            wl.evo_aspirate(
+                lw,
+                "A01",
+                labware_position=(30, 2),
+                tips=[Tip.T2],
+                volumes=20,
+                liquid_class="PowerSuck",
+            )
+        assert len(wl) == 1
+        assert "B;Aspirate" in wl[0]
+        assert lw.volumes[0, 0] == 30
+        pass
+
+    def test_evo_dispense(self) -> None:
+        lw = Labware("A", 4, 5, min_volume=10, max_volume=100)
+        with Worklist() as wl:
+            wl.evo_dispense(
+                lw,
+                "A01",
+                labware_position=(30, 2),
+                tips=[Tip.T2],
+                volumes=50,
+                liquid_class="PowerPee",
+            )
+        assert len(wl) == 1
+        assert "B;Dispense" in wl[0]
+        assert lw.volumes[0, 0] == 50
+        pass
+
+    def test_evo_wash(self) -> None:
+        with Worklist() as wl:
+            wl.evo_wash(
+                tips=[Tip.T1, Tip.T5],
+                waste_location=(40, 2),
+                cleaner_location=(40, 3),
+            )
+        assert len(wl) == 1
+        assert "B;Wash" in wl[0]
+        pass

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Labwares, Tip
 from robotools.evotools.worklist import Worklist
 from robotools.liquidhandling.labware import Labware, Trough
+from robotools.worklists.exceptions import InvalidOperationError
 from robotools.worklists.utils import (
     optimize_partition_by,
     partition_by_column,

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -3,11 +3,13 @@
 import logging
 import textwrap
 import warnings
-from typing import Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from robotools import liquidhandling
+from robotools.evotools import commands
+from robotools.evotools.types import Tip
 from robotools.worklists.base import BaseWorklist
 from robotools.worklists.utils import (
     optimize_partition_by,
@@ -22,6 +24,187 @@ logger = logging.getLogger(__name__)
 
 class EvoWorklist(BaseWorklist):
     """Context manager for the creation of Tecan EVO worklists."""
+
+    def evo_aspirate(
+        self,
+        labware: liquidhandling.Labware,
+        wells: Union[str, List[str]],
+        labware_position: Tuple[int, int],
+        tips: Union[List[Tip], List[int]],
+        volumes: Union[float, List[float]],
+        liquid_class: str,
+        *,
+        arm: int = 0,
+        label: Optional[str] = None,
+    ) -> None:
+        """Performs aspiration from the provided labware. Is identical to the aspirate command inside the EvoWARE.
+        Thus, several wells in a single column can be targeted.
+
+        Parameters
+        ----------
+        labware : liquidhandling.Labware
+            Source labware
+        labware_position : tuple
+            Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        wells : list of str or iterable
+            List with target well ID(s)
+        tips : list
+            Tip(s) that will be selected; use either a list with integers from 1 - 8 or with tip.T1 - tip.T8
+        volumes : float or iterable
+            Volume(s) in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
+        liquid_class : str, optional
+            Overwrites the liquid class for this step (max 32 characters)
+        arm : int
+            Which LiHa to use, if more than one is available
+        label : str
+            Label of the operation to log into labware history
+        """
+        # diferentiate between what is needed for volume calculation and for pipetting commands
+        wells_calc = np.array(wells).flatten("F")
+        volumes_calc = np.array(volumes).flatten("F")
+        if len(volumes_calc) == 1:
+            volumes_calc = np.repeat(volumes_calc, len(wells_calc))
+        labware.remove(wells_calc, volumes_calc, label)
+        self.comment(label)
+        cmd = commands.evo_aspirate(
+            n_rows=labware.n_rows,
+            n_columns=labware.n_columns,
+            wells=wells,
+            labware_position=labware_position,
+            volume=volumes,
+            liquid_class=liquid_class,
+            tips=tips,
+            arm=arm,
+            max_volume=self.max_volume,
+        )
+        self.append(cmd)
+        return
+
+    def evo_dispense(
+        self,
+        labware: liquidhandling.Labware,
+        wells: Union[str, List[str]],
+        labware_position: Tuple[int, int],
+        tips: Union[List[Tip], List[int]],
+        volumes: Union[float, List[float]],
+        liquid_class: str,
+        *,
+        arm: int = 0,
+        label: Optional[str] = None,
+        compositions: Optional[List[Optional[Dict[str, float]]]] = None,
+    ) -> None:
+        """Performs dispensation from the provided labware. Is identical to the dispense command inside the EvoWARE.
+        Thus, several wells in a single column can be targeted.
+
+        Parameters
+        ----------
+        labware : liquidhandling.Labware
+            Source labware
+        labware_position : tuple
+            Grid position of the target labware on the robotic deck and site position on its carrier, e.g. labware on grid 38, site 2 -> (38,2)
+        wells : list of str or iterable
+            List with target well ID(s)
+        tips : list
+            Tip(s) that will be selected; use either a list with integers from 1 - 8 or with tip.T1 - tip.T8
+        volumes : float or iterable
+            Volume(s) in microliters (will be rounded to 2 decimal places); if several tips are used, these tips may aspirate individual volumes -> use list in these cases
+        liquid_class : str, optional
+            Overwrites the liquid class for this step (max 32 characters)
+        arm : int
+            Which LiHa to use, if more than one is available
+        label : str
+            Label of the operation to log into labware history
+        compositions : list
+            Iterable of liquid compositions
+        """
+        # diferentiate between what is needed for volume calculation and for pipetting commands
+        wells_calc = np.array(wells).flatten("F")
+        volumes_calc = np.array(volumes).flatten("F")
+        if len(volumes_calc) == 1:
+            volumes_calc = np.repeat(volumes_calc, len(wells_calc))
+        labware.add(wells_calc, volumes_calc, label, compositions=compositions)
+        self.comment(label)
+        cmd = commands.evo_dispense(
+            n_rows=labware.n_rows,
+            n_columns=labware.n_columns,
+            wells=wells,
+            labware_position=labware_position,
+            volume=volumes,
+            liquid_class=liquid_class,
+            tips=tips,
+            arm=arm,
+            max_volume=self.max_volume,
+        )
+        self.append(cmd)
+        return
+
+    def evo_wash(
+        self,
+        *,
+        tips: Union[List[Tip], List[int]],
+        waste_location: Tuple[int, int],
+        cleaner_location: Tuple[int, int],
+        arm: int = 0,
+        waste_vol: float = 3.0,
+        waste_delay: int = 500,
+        cleaner_vol: float = 4.0,
+        cleaner_delay: int = 500,
+        airgap: int = 10,
+        airgap_speed: int = 70,
+        retract_speed: int = 30,
+        fastwash: int = 1,
+        low_volume: int = 0,
+    ) -> None:
+        """Command for aspirating with the EvoWARE aspirate command. As many wells in one column may be selected as your liquid handling arm has pipettes.
+        This method generates the full command (as can be observed when opening a .esc file with an editor) and calls upon other functions to create the code string
+        specifying the target wells.
+
+        Parameters
+        ----------
+        tips : list
+            Tip(s) that will be selected; use either a list with integers from 1 - 8 or with tip.T1 - tip.T8
+        waste_location : tuple
+            Tuple with grid position (1-67) and site number (0-127) of waste as integers
+        cleaner_location : tuple
+            Tuple with grid position (1-67) and site number (0-127) of cleaner as integers
+        arm : int
+            number of the LiHa performing the action: 0 = LiHa 1, 1 = LiHa 2
+        waste_vol: float
+            Volume in waste in mL (0-100)
+        waste_delay : int
+            Delay before closing valves in waste in ms (0-1000)
+        cleaner_vol: float
+            Volume in cleaner in mL (0-100)
+        cleaner_delay : int
+            Delay before closing valves in cleaner in ms (0-1000)
+        airgap : int
+            Volume of airgap in µL which is aspirated after washing the tips (system trailing airgap) (0-100)
+        airgap_speed : int
+            Speed of airgap aspiration in µL/s (1-1000)
+        retract_speed : int
+            Retract speed in mm/s (1-100)
+        fastwash : int
+            Use fast-wash module = 1, don't use it = 0
+        low_volume : int
+            Use pinch valves = 1, don't use them = 0
+        """
+        cmd = commands.evo_wash(
+            tips=tips,
+            waste_location=waste_location,
+            cleaner_location=cleaner_location,
+            arm=arm,
+            waste_vol=waste_vol,
+            waste_delay=waste_delay,
+            cleaner_vol=cleaner_vol,
+            cleaner_delay=cleaner_delay,
+            airgap=airgap,
+            airgap_speed=airgap_speed,
+            retract_speed=retract_speed,
+            fastwash=fastwash,
+            low_volume=low_volume,
+        )
+        self.append(cmd)
+        return
 
     def transfer(
         self,

--- a/robotools/liquidhandling/test_composition.py
+++ b/robotools/liquidhandling/test_composition.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from robotools.evotools import Worklist
+from robotools.evotools.worklist import EvoWorklist
 from robotools.liquidhandling.composition import (
     combine_composition,
     get_initial_composition,
@@ -261,7 +261,7 @@ class TestCompositionTracking:
         G = Trough("glucose", 4, 1, min_volume=0, max_volume=10000, initial_volumes=10000)
         D = Labware("dilutions", 4, 2, min_volume=0, max_volume=10000)
 
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             # 100 % in first column
             wl.transfer(G, G.wells, D, D.wells[:, 0], volumes=[1000, 800, 600, 550])
             wl.transfer(W, W.wells, D, D.wells[:, 0], volumes=[0, 200, 400, 450])
@@ -282,7 +282,7 @@ class TestCompositionTracking:
         G = Trough("glucose", 2, 1, min_volume=0, max_volume=10000, initial_volumes=10000)
         D = Labware("dilutions", 2, 4, min_volume=0, max_volume=10000)
 
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             # transfer some glucose
             wl.transfer(
                 G,
@@ -318,7 +318,7 @@ class TestCompositionTracking:
         A._composition["water"] = 0.25 * np.ones_like(A.volumes)
         A._composition["salt"] = 0.75 * np.ones_like(A.volumes)
         A._volumes = np.ones_like(A.volumes) * 500
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             wl.transfer(A, A.wells, A, A.wells, volumes=300)
         # make sure that the composition of the liquid is not changed
         np.testing.assert_array_equal(A.composition["water"], 0.25 * np.ones_like(A.volumes))

--- a/robotools/test_utils.py
+++ b/robotools/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from robotools.evotools import Worklist
+from robotools.evotools import EvoWorklist
 from robotools.liquidhandling import Labware, Trough
 from robotools.utils import DilutionPlan, get_trough_wells
 
@@ -140,7 +140,7 @@ class TestDilutionPlan:
         diluent = Trough("Diluent", 4, 2, min_volume=0, max_volume=20_000, initial_volumes=[0, 20_000])
         dilution = Labware("Dilution", 6, 8, min_volume=0, max_volume=2000)
         destination = Labware("Destination", 7, 10, min_volume=0, max_volume=1000)
-        with Worklist() as wl:
+        with EvoWorklist() as wl:
             plan.to_worklist(
                 worklist=wl,
                 stock=stock,
@@ -183,8 +183,8 @@ class TestDilutionPlan:
         ]
 
         # Split the work across two worklists (also via the hook)
-        wl_one = Worklist()
-        wl_two = Worklist()
+        wl_one = EvoWorklist()
+        wl_two = EvoWorklist()
 
         def pre_mix(col, wl):
             wl.comment(f"Pre-mix on column {col}")

--- a/robotools/worklists/__init__.py
+++ b/robotools/worklists/__init__.py
@@ -1,1 +1,2 @@
-from robotools.worklists.base import BaseWorklist, CompatibilityError
+from robotools.worklists.base import BaseWorklist
+from robotools.worklists.exceptions import CompatibilityError, InvalidOperationError

--- a/robotools/worklists/base.py
+++ b/robotools/worklists/base.py
@@ -8,17 +8,13 @@ from typing import Dict, Iterable, List, Optional, Sequence, Union
 import numpy
 
 from robotools import liquidhandling
-from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Tip
+from robotools.worklists.exceptions import CompatibilityError, InvalidOperationError
 from robotools.worklists.utils import prepare_aspirate_dispense_parameters
 
-__all__ = ("BaseWorklist", "CompatibilityError")
+__all__ = ("BaseWorklist",)
 
 logger = logging.getLogger(__name__)
-
-
-class CompatibilityError(NotImplementedError):
-    """Exception that's thrown when device-specific implementations are required."""
 
 
 class BaseWorklist(list):

--- a/robotools/worklists/exceptions.py
+++ b/robotools/worklists/exceptions.py
@@ -11,4 +11,4 @@ class CompatibilityError(NotImplementedError):
 
 
 class InvalidOperationError(Exception):
-    """When an operation can not be performed under the present circumstances."""
+    """When an operation cannot be performed under the present circumstances."""

--- a/robotools/worklists/exceptions.py
+++ b/robotools/worklists/exceptions.py
@@ -1,0 +1,14 @@
+"""Exceptions related to liquid handling with worklists."""
+
+__all__ = (
+    "CompatibilityError",
+    "InvalidOperationError",
+)
+
+
+class CompatibilityError(NotImplementedError):
+    """Exception that's thrown when device-specific implementations are required."""
+
+
+class InvalidOperationError(Exception):
+    """When an operation can not be performed under the present circumstances."""

--- a/robotools/worklists/test_base.py
+++ b/robotools/worklists/test_base.py
@@ -1,0 +1,891 @@
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robotools.evotools.types import Tip
+from robotools.liquidhandling.labware import Labware, Trough
+from robotools.worklists import BaseWorklist
+from robotools.worklists.exceptions import CompatibilityError, InvalidOperationError
+from robotools.worklists.utils import (
+    partition_by_column,
+    partition_volume,
+    prepare_aspirate_dispense_parameters,
+)
+
+
+class TestWorklist:
+    def test_context(self) -> None:
+        with BaseWorklist() as worklist:
+            assert worklist is not None
+        return
+
+    def test_parameter_validation(self) -> None:
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label=None, position=1, volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label=15, position=1, volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="thisisaveryverylongracklabelthatexceedsthemaximumlength", position=1, volume=15
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="rack label; with semicolon", position=1, volume=15
+            )
+        prepare_aspirate_dispense_parameters(rack_label="valid rack label", position=1, volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=None, volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position="3", volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=-1, volume=15)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=None)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="nan")
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=float("nan"))
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=-15.4)
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="bla")
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume="15")
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=20)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=23.78)
+        prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=np.array(23.4))
+
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, liquid_class=None
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, liquid_class="liquid;class"
+            )
+        prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, liquid_class="valid liquid class"
+        )
+
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=4
+        )
+        assert tip == 8
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=Tip.T5
+        )
+        assert tip == 16
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T4, 4)
+        )
+        assert tip == 8
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=[Tip.T1, 4]
+        )
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=[1, 4]
+        )
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=[1, Tip.T4]
+        )
+        assert tip == 9
+        _, _, _, _, tip, _, _, _, _ = prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, tip=Tip.Any
+        )
+        assert tip == ""
+
+        with pytest.raises(ValueError, match="no Tip.Any elements are allowed"):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, tip=(Tip.T1, Tip.Any)
+            )
+        with pytest.raises(ValueError, match="tip must be an int between 1 and 8, Tip or Iterable"):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=None)
+        with pytest.raises(ValueError, match="it may only contain int or Tip values"):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, tip=[1, 2.6]
+            )
+        with pytest.raises(ValueError, match="should be an int between 1 and 8 for _int_to_tip"):
+            prepare_aspirate_dispense_parameters(rack_label="WaterTrough", position=1, volume=15, tip=12)
+
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, rack_id=None
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, rack_id="invalid;rack"
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough",
+                position=1,
+                volume=15,
+                rack_id="thisisaveryverylongrackthatexceedsthemaximumlength",
+            )
+        prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, rack_id="1235464"
+        )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, rack_type=None
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, rack_type="invalid;rack type"
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough",
+                position=1,
+                volume=15,
+                rack_type="thisisaveryverylongracktypethatexceedsthemaximumlength",
+            )
+        prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, rack_type="valid rack type"
+        )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, forced_rack_type=None
+            )
+        with pytest.raises(ValueError):
+            prepare_aspirate_dispense_parameters(
+                rack_label="WaterTrough", position=1, volume=15, forced_rack_type="invalid;forced rack type"
+            )
+        prepare_aspirate_dispense_parameters(
+            rack_label="WaterTrough", position=1, volume=15, forced_rack_type="valid forced rack type"
+        )
+        return
+
+    def test_comment(self) -> None:
+        with BaseWorklist() as wl:
+            # empty and None comments should be ignored
+            wl.comment("")
+            wl.comment(None)
+            # this will be the first actual comment
+            wl.comment("This is a simple comment")
+            with pytest.raises(ValueError):
+                wl.comment("It must not contain ; semicolons")
+            wl.comment(
+                """
+            But it may very well be
+            a multiline comment
+            """
+            )
+            exp = ["C;This is a simple comment", "C;But it may very well be", "C;a multiline comment"]
+            assert wl == exp
+        return
+
+    def test_wash(self) -> None:
+        with BaseWorklist() as wl:
+            wl.wash()
+            with pytest.raises(ValueError):
+                wl.wash(scheme=15)
+            with pytest.raises(ValueError):
+                wl.wash(scheme="2")
+            wl.wash(scheme=1)
+            wl.wash(scheme=2)
+            wl.wash(scheme=3)
+            wl.wash(scheme=4)
+            exp = [
+                "W1;",
+                "W1;",
+                "W2;",
+                "W3;",
+                "W4;",
+            ]
+            assert wl == exp
+        return
+
+    def test_decontaminate(self) -> None:
+        with BaseWorklist() as wl:
+            wl.decontaminate()
+            assert wl == ["WD;"]
+        return
+
+    def test_flush(self) -> None:
+        with BaseWorklist() as wl:
+            wl.flush()
+            assert wl == ["F;"]
+        return
+
+    def test_commit(self) -> None:
+        with BaseWorklist() as wl:
+            wl.commit()
+            assert wl == ["B;"]
+        return
+
+    def test_set_diti(self) -> None:
+        with BaseWorklist() as wl:
+            wl.set_diti(diti_index=1)
+            with pytest.raises(InvalidOperationError):
+                wl.set_diti(diti_index=2)
+            wl.commit()
+            wl.set_diti(diti_index=2)
+            assert wl == [
+                "S;1",
+                "B;",
+                "S;2",
+            ]
+        return
+
+    def test_aspirate_single(self) -> None:
+        with BaseWorklist() as wl:
+            wl.aspirate_well("WaterTrough", 1, 200)
+            assert wl[-1] == "A;WaterTrough;;;1;;200.00;;;;"
+            wl.aspirate_well(
+                "WaterTrough", 1, 200, rack_id="12345", rack_type="my_rack_id", tube_id="my_tube_id"
+            )
+            assert wl[-1] == "A;WaterTrough;12345;my_rack_id;1;my_tube_id;200.00;;;;"
+            wl.aspirate_well(
+                "WaterTrough", 1, 200, liquid_class="my_liquid_class", tip=8, forced_rack_type="forced_rack"
+            )
+            assert wl[-1] == "A;WaterTrough;;;1;;200.00;my_liquid_class;;128;forced_rack"
+        return
+
+    def test_dispense_single(self) -> None:
+        with BaseWorklist() as wl:
+            wl.dispense_well("WaterTrough", 1, 200)
+            assert wl[-1] == "D;WaterTrough;;;1;;200.00;;;;"
+            wl.dispense_well(
+                "WaterTrough", 1, 200, rack_id="12345", rack_type="my_rack_id", tube_id="my_tube_id"
+            )
+            assert wl[-1] == "D;WaterTrough;12345;my_rack_id;1;my_tube_id;200.00;;;;"
+            wl.dispense_well(
+                "WaterTrough", 1, 200, liquid_class="my_liquid_class", tip=8, forced_rack_type="forced_rack"
+            )
+            assert wl[-1] == "D;WaterTrough;;;1;;200.00;my_liquid_class;;128;forced_rack"
+        return
+
+    def test_generic_transfer_raises_notimplemented(self) -> None:
+        with pytest.raises(CompatibilityError, match="generic .*? type"):
+            with BaseWorklist() as wl:
+                wl.transfer(None, "A01", None, "A01", 100)
+        return
+
+    def test_accepts_path(self):
+        fp = Path(tempfile.gettempdir(), os.urandom(24).hex() + ".gwl")
+        try:
+            with BaseWorklist(fp) as wl:
+                wl.comment("Test")
+            assert isinstance(wl._filepath, Path)
+            assert fp.exists()
+        finally:
+            fp.unlink(missing_ok=True)
+        return
+
+    def test_save(self) -> None:
+        tf = tempfile.mktemp() + ".gwl"
+        error = None
+        try:
+            with BaseWorklist() as worklist:
+                worklist.flush()
+                worklist.save(tf)
+                assert os.path.exists(tf)
+                # also check that the file can be overwritten if it exists already
+                worklist.save(tf)
+            assert os.path.exists(tf)
+            with open(tf) as file:
+                lines = file.readlines()
+                assert lines == ["F;"]
+        except Exception as ex:
+            error = ex
+        finally:
+            os.remove(tf)
+        assert os.path.exists(tf == False)
+        if error:
+            raise error
+        return
+
+    def test_autosave(self) -> None:
+        tf = tempfile.mktemp() + ".gwl"
+        error = None
+        try:
+            with BaseWorklist(tf) as worklist:
+                worklist.flush()
+            assert os.path.exists(tf)
+            with open(tf) as file:
+                lines = file.readlines()
+                assert lines == ["F;"]
+        except Exception as ex:
+            error = ex
+        finally:
+            os.remove(tf)
+        assert os.path.exists(tf == False)
+        if error:
+            raise error
+        return
+
+
+class TestStandardLabwareWorklist:
+    def test_aspirate(self) -> None:
+        source = Labware("SourceLW", rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
+        with BaseWorklist() as wl:
+            wl.aspirate(source, ["A01", "A02", "C02"], 50, label=None)
+            wl.aspirate(source, ["A03", "B03", "C03"], [10, 20, 30.5], label="second aspirate")
+            assert wl == [
+                "A;SourceLW;;;1;;50.00;;;;",
+                "A;SourceLW;;;4;;50.00;;;;",
+                "A;SourceLW;;;6;;50.00;;;;",
+                "C;second aspirate",
+                "A;SourceLW;;;7;;10.00;;;;",
+                "A;SourceLW;;;8;;20.00;;;;",
+                "A;SourceLW;;;9;;30.50;;;;",
+            ]
+            np.testing.assert_array_equal(
+                source.volumes,
+                [
+                    [150, 150, 190],
+                    [200, 200, 180],
+                    [200, 150, 169.5],
+                ],
+            )
+            assert len(source.history) == 3
+        return
+
+    def test_aspirate_2d_volumes(self) -> None:
+        source = Labware("SourceLW", rows=2, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
+        with BaseWorklist() as wl:
+            wl.aspirate(
+                source,
+                source.wells[:, :2],
+                volumes=np.array(
+                    [
+                        [20, 30],
+                        [15.3, 17.53],
+                    ]
+                ),
+            )
+            assert wl == [
+                "A;SourceLW;;;1;;20.00;;;;",
+                "A;SourceLW;;;2;;15.30;;;;",
+                "A;SourceLW;;;3;;30.00;;;;",
+                "A;SourceLW;;;4;;17.53;;;;",
+            ]
+            np.testing.assert_array_equal(source.volumes, [[180, 170, 200], [200 - 15.3, 200 - 17.53, 200]])
+            assert len(source.history) == 2
+        return
+
+    def test_dispense(self) -> None:
+        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
+        with BaseWorklist() as wl:
+            wl.dispense(destination, ["A01", "A02", "A03"], 150, label=None)
+            wl.dispense(destination, ["B01", "B02", "B03"], [10, 20, 30.5], label="second dispense")
+            assert wl == [
+                "D;DestinationLW;;;1;;150.00;;;;",
+                "D;DestinationLW;;;3;;150.00;;;;",
+                "D;DestinationLW;;;5;;150.00;;;;",
+                "C;second dispense",
+                "D;DestinationLW;;;2;;10.00;;;;",
+                "D;DestinationLW;;;4;;20.00;;;;",
+                "D;DestinationLW;;;6;;30.50;;;;",
+            ]
+            np.testing.assert_array_equal(
+                destination.volumes,
+                [
+                    [150, 150, 150],
+                    [10, 20, 30.5],
+                ],
+            )
+            assert len(destination.history) == 3
+        return
+
+    def test_dispense_2d_volumes(self) -> None:
+        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
+        with BaseWorklist() as wl:
+            wl.dispense(
+                destination,
+                destination.wells[:, :2],
+                volumes=np.array(
+                    [
+                        [20, 30],
+                        [15.3, 17.53],
+                    ]
+                ),
+            )
+            assert wl == [
+                "D;DestinationLW;;;1;;20.00;;;;",
+                "D;DestinationLW;;;2;;15.30;;;;",
+                "D;DestinationLW;;;3;;30.00;;;;",
+                "D;DestinationLW;;;4;;17.53;;;;",
+            ]
+            np.testing.assert_array_equal(destination.volumes, [[20, 30, 0], [15.3, 17.53, 0]])
+            assert len(destination.history) == 2
+        return
+
+    def test_skip_zero_volumes(self) -> None:
+        source = Labware("SourceLW", rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200)
+        destination = Labware("DestinationLW", rows=2, columns=3, min_volume=10, max_volume=200)
+        with BaseWorklist() as wl:
+            wl.aspirate(source, ["A03", "B03", "C03"], [10, 0, 30.5])
+            wl.dispense(destination, ["B01", "B02", "B03"], [10, 0, 30.5])
+            assert wl == [
+                "A;SourceLW;;;7;;10.00;;;;",
+                "A;SourceLW;;;9;;30.50;;;;",
+                "D;DestinationLW;;;2;;10.00;;;;",
+                "D;DestinationLW;;;6;;30.50;;;;",
+            ]
+            np.testing.assert_array_equal(
+                source.volumes,
+                [
+                    [200, 200, 190],
+                    [200, 200, 200],
+                    [200, 200, 169.5],
+                ],
+            )
+            np.testing.assert_array_equal(
+                destination.volumes,
+                [
+                    [0, 0, 0],
+                    [10, 0, 30.5],
+                ],
+            )
+            assert len(destination.history) == 2
+        return
+
+    def test_tip_selection(self) -> None:
+        A = Labware("A", 3, 4, min_volume=10, max_volume=250, initial_volumes=100)
+        with BaseWorklist() as wl:
+            wl.aspirate(A, "A01", 10, tip=1)
+            wl.aspirate(A, "A01", 10, tip=2)
+            wl.aspirate(A, "A01", 10, tip=3)
+            wl.aspirate(A, "A01", 10, tip=4)
+            wl.aspirate(A, "A01", 10, tip=5)
+            wl.aspirate(A, "A01", 10, tip=6)
+            wl.aspirate(A, "A01", 10, tip=7)
+            wl.aspirate(A, "A01", 10, tip=8)
+            wl.dispense(A, "B01", 10, tip=Tip.T1)
+            wl.dispense(A, "B02", 10, tip=Tip.T2)
+            wl.dispense(A, "B03", 10, tip=Tip.T3)
+            wl.dispense(A, "B04", 10, tip=Tip.T4)
+            wl.dispense(A, "B04", 10, tip=Tip.T5)
+            wl.dispense(A, "B04", 10, tip=Tip.T6)
+            wl.dispense(A, "B04", 10, tip=Tip.T7)
+            wl.dispense(A, "B04", 10, tip=Tip.T8)
+            assert wl == [
+                "A;A;;;1;;10.00;;;1;",
+                "A;A;;;1;;10.00;;;2;",
+                "A;A;;;1;;10.00;;;4;",
+                "A;A;;;1;;10.00;;;8;",
+                "A;A;;;1;;10.00;;;16;",
+                "A;A;;;1;;10.00;;;32;",
+                "A;A;;;1;;10.00;;;64;",
+                "A;A;;;1;;10.00;;;128;",
+                "D;A;;;2;;10.00;;;1;",
+                "D;A;;;5;;10.00;;;2;",
+                "D;A;;;8;;10.00;;;4;",
+                "D;A;;;11;;10.00;;;8;",
+                "D;A;;;11;;10.00;;;16;",
+                "D;A;;;11;;10.00;;;32;",
+                "D;A;;;11;;10.00;;;64;",
+                "D;A;;;11;;10.00;;;128;",
+            ]
+        return
+
+    def test_tip_mask(self) -> None:
+        A = Labware("A", 3, 4, min_volume=10, max_volume=250)
+
+        # Only allow three specific tips to be used...
+        tips = [
+            Tip.T1,  # 1 +
+            Tip.T4,  # 8 +
+            Tip.T7,  # 64
+            # The sum of tips is = 73
+        ]
+        with BaseWorklist() as wl:
+            wl.dispense(A, "A01", 10, tip=tips)
+        assert wl[-1] == "D;A;;;1;;10.00;;;73;"
+        pass
+
+
+class TestTroughLabwareWorklist:
+    def test_aspirate(self) -> None:
+        source = Trough(
+            "SourceLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200
+        )
+        with BaseWorklist() as wl:
+            wl.aspirate(source, ["A01", "A02", "C02"], 50)
+            wl.aspirate(source, ["A01", "A02", "C02"], [1, 2, 3])
+            assert wl == [
+                "A;SourceLW;;;1;;50.00;;;;",
+                "A;SourceLW;;;4;;50.00;;;;",
+                "A;SourceLW;;;6;;50.00;;;;",
+                "A;SourceLW;;;1;;1.00;;;;",
+                "A;SourceLW;;;4;;2.00;;;;",
+                "A;SourceLW;;;6;;3.00;;;;",
+            ]
+            np.testing.assert_array_equal(source.volumes, [[149, 95, 200]])
+            assert len(source.history) == 3
+        return
+
+    def test_dispense(self) -> None:
+        destination = Trough("DestinationLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200)
+        with BaseWorklist() as wl:
+            wl.dispense(destination, ["A01", "A02", "A03", "B01"], 50)
+            wl.dispense(destination, ["A01", "A02", "C02"], [1, 2, 3])
+            assert wl == [
+                "D;DestinationLW;;;1;;50.00;;;;",
+                "D;DestinationLW;;;4;;50.00;;;;",
+                "D;DestinationLW;;;7;;50.00;;;;",
+                "D;DestinationLW;;;2;;50.00;;;;",
+                "D;DestinationLW;;;1;;1.00;;;;",
+                "D;DestinationLW;;;4;;2.00;;;;",
+                "D;DestinationLW;;;6;;3.00;;;;",
+            ]
+            np.testing.assert_array_equal(destination.volumes, [[101, 55, 50]])
+            assert len(destination.history) == 3
+        return
+
+
+class TestLargeVolumeHandling:
+    def testpartition_volume_helper(self) -> None:
+        assert [] == partition_volume(0, max_volume=950)
+        assert [550.3] == partition_volume(550.3, max_volume=950)
+        assert [500 == 500], partition_volume(1000, max_volume=950)
+        assert [500 == 499], partition_volume(999, max_volume=950)
+        assert [667 == 667, 666], partition_volume(2000, max_volume=950)
+        return
+
+    def test_worklist_constructor(self) -> None:
+        with pytest.raises(ValueError):
+            with BaseWorklist(max_volume=None) as wl:
+                pass
+        with BaseWorklist(max_volume=800, auto_split=True) as wl:
+            assert wl.max_volume == 800
+            assert wl.auto_split == True
+        with BaseWorklist(max_volume=800, auto_split=False) as wl:
+            assert wl.max_volume == 800
+            assert wl.auto_split == False
+        return
+
+    def test_max_volume_checking(self) -> None:
+        source = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        destination = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        with BaseWorklist(max_volume=900, auto_split=False) as wl:
+            with pytest.raises(InvalidOperationError):
+                wl.aspirate_well("WaterTrough", 1, 1000)
+            with pytest.raises(InvalidOperationError):
+                wl.dispense_well("WaterTrough", 1, 1000)
+            with pytest.raises(InvalidOperationError):
+                wl.aspirate(source, ["A01", "A02", "C02"], 1000)
+            with pytest.raises(InvalidOperationError):
+                wl.dispense(source, ["A01", "A02", "C02"], 1000)
+
+        source = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        destination = Trough(
+            "WaterTrough",
+            virtual_rows=3,
+            columns=3,
+            min_volume=1000,
+            max_volume=100 * 1000,
+            initial_volumes=50 * 1000,
+        )
+        with BaseWorklist(max_volume=1200) as wl:
+            wl.aspirate_well("WaterTrough", 1, 1000)
+            wl.dispense_well("WaterTrough", 1, 1000)
+            wl.aspirate(source, ["A01", "A02", "C02"], 1000)
+            wl.dispense(source, ["A01", "A02", "C02"], 1000)
+        return
+
+    def testpartition_by_columns_source(self) -> None:
+        column_groups = partition_by_column(
+            ["A01", "B01", "A03", "B03", "C02"],
+            ["A01", "B01", "C01", "D01", "E01"],
+            [2500, 3500, 1000, 500, 2000],
+            partition_by="source",
+        )
+        assert len(column_groups) == 3
+        assert column_groups[0] == (
+            ["A01", "B01"],
+            ["A01", "B01"],
+            [2500, 3500],
+        )
+        assert column_groups[1] == (
+            ["C02"],
+            ["E01"],
+            [2000],
+        )
+        assert column_groups[2] == (
+            ["A03", "B03"],
+            ["C01", "D01"],
+            [1000, 500],
+        )
+        return
+
+    def testpartition_by_columns_destination(self) -> None:
+        column_groups = partition_by_column(
+            ["A01", "B01", "A03", "B03", "C02"],
+            ["A01", "B01", "C02", "D01", "E02"],
+            [2500, 3500, 1000, 500, 2000],
+            partition_by="destination",
+        )
+        assert len(column_groups) == 2
+        assert column_groups[0] == (
+            ["A01", "B01", "B03"],
+            ["A01", "B01", "D01"],
+            [2500, 3500, 500],
+        )
+        assert column_groups[1] == (
+            ["A03", "C02"],
+            ["C02", "E02"],
+            [1000, 2000],
+        )
+        return
+
+    def testpartition_by_columns_sorting(self) -> None:
+        # within every column, the wells are supposed to be sorted by row
+        # The test source wells are partially sorted (col 1 is in the right order, col 3 in the reverse)
+        # The result is expected to always be sorted by row, either in the source (first case) or destination:
+
+        # by source
+        column_groups = partition_by_column(
+            ["A01", "B01", "B03", "A03", "C02"],
+            ["B01", "A01", "C01", "D01", "E01"],
+            [2500, 3500, 1000, 500, 2000],
+            partition_by="source",
+        )
+        assert len(column_groups) == 3
+        assert column_groups[0] == (
+            ["A01", "B01"],
+            ["B01", "A01"],
+            [2500, 3500],
+        )
+        assert column_groups[1] == (
+            ["C02"],
+            ["E01"],
+            [2000],
+        )
+        assert column_groups[2] == (
+            ["A03", "B03"],
+            ["D01", "C01"],
+            [500, 1000],
+        )
+
+        # by destination
+        # (destination wells are across 3 columns; reverse order in col 1, forward order in col 3)
+        column_groups = partition_by_column(
+            ["A01", "B01", "B03", "A03", "C02"],
+            ["B01", "A01", "C03", "D03", "E02"],
+            [2500, 3500, 1000, 500, 2000],
+            partition_by="destination",
+        )
+        assert len(column_groups) == 3
+        assert column_groups[0] == (
+            ["B01", "A01"],
+            ["A01", "B01"],
+            [3500, 2500],
+        )
+        assert column_groups[1] == (
+            ["C02"],
+            ["E02"],
+            [2000],
+        )
+        assert column_groups[2] == (
+            ["B03", "A03"],
+            ["C03", "D03"],
+            [1000, 500],
+        )
+        return
+
+
+class TestReagentDistribution:
+    def test_parameter_validation(self, caplog) -> None:
+        with BaseWorklist() as wl:
+            with pytest.raises(ValueError):
+                wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=50, direction="invalid")
+            with pytest.raises(ValueError):
+                # one excluded well not in the destination range
+                wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=50, exclude_wells=[18, 19, 23])
+        with pytest.raises(InvalidOperationError):
+            with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
+                with BaseWorklist(max_volume=950) as wl:
+                    # dispense more than diluter volume
+                    wl.reagent_distribution("S1", 1, 8, "D1", 1, 20, volume=1200)
+            assert "account for a large dispense" in caplog.records[0].message
+        return
+
+    def test_default_parameterization(self) -> None:
+        with BaseWorklist() as wl:
+            wl.reagent_distribution("S1", 1, 20, "D1", 2, 21, volume=50)
+        assert wl[0] == "R;S1;;;1;20;D1;;;2;21;50;;1;1;0"
+        return
+
+    def test_full_parameterization(self) -> None:
+        with BaseWorklist() as wl:
+            wl.reagent_distribution(
+                "S1",
+                1,
+                20,
+                "D1",
+                2,
+                21,
+                volume=50,
+                diti_reuse=2,
+                multi_disp=3,
+                exclude_wells=[2, 4, 8],
+                liquid_class="TestLC",
+                direction="right_to_left",
+                src_rack_type="MP3Pos",
+                dst_rack_type="MP4Pos",
+                src_rack_id="S1234",
+                dst_rack_id="D1234",
+            )
+        assert wl[0] == "R;S1;S1234;MP3Pos;1;20;D1;D1234;MP4Pos;2;21;50;TestLC;2;3;1;2;4;8"
+        return
+
+    def test_large_volume_multi_disp_adaption(self) -> None:
+        with BaseWorklist() as wl:
+            wl.reagent_distribution(
+                "S1",
+                1,
+                8,
+                "D1",
+                1,
+                96,
+                volume=400,
+                multi_disp=6,
+            )
+        assert wl[0] == "R;S1;;;1;8;D1;;;1;96;400;;1;2;0"
+        return
+
+    def test_oo_parameter_validation(self) -> None:
+        with BaseWorklist() as wl:
+            src = Labware("NotATrough", 6, 2, min_volume=20, max_volume=1000)
+            dst = Labware("48deep", 6, 8, min_volume=50, max_volume=4000)
+            with pytest.raises(ValueError):
+                wl.distribute(src, 0, dst, dst.wells[:, :3], volume=50)
+        with BaseWorklist(max_volume=950) as wl:
+            src = Trough("Water", 8, 2, min_volume=20, max_volume=1000)
+            dst = Labware("48deep", 6, 8, min_volume=50, max_volume=4000)
+            with pytest.raises(InvalidOperationError):
+                wl.distribute(src, 0, dst, dst.wells[:, :3], volume=1200)
+        return
+
+    def test_oo_example_1(self) -> None:
+        src = Trough(
+            "T3",
+            8,
+            1,
+            min_volume=20,
+            max_volume=100 * 1000,
+            initial_volumes=100 * 1000,
+        )
+        dst = Labware("MTP-96-3", 8, 12, min_volume=20, max_volume=300)
+        with BaseWorklist() as wl:
+            all_dst_wells = set(dst.wells.flatten("F"))
+            skip_wells = set("C04,C07,E09,F06,B11".split(","))
+            dst_wells = list(all_dst_wells.difference(skip_wells))
+            wl.distribute(
+                src,
+                0,
+                dst,
+                dst_wells,
+                volume=100,
+                liquid_class="Water",
+                diti_reuse=1,
+                multi_disp=6,
+                direction="left_to_right",
+                src_rack_type="Trough 100ml",
+                dst_rack_type="96 Well Microplate",
+                label="Test Label",
+            )
+        assert wl[0] == "C;Test Label"
+        assert (
+            wl[1] == "R;T3;;Trough 100ml;1;8;MTP-96-3;;96 Well Microplate;1;96;100;Water;1;6;0;27;46;51;69;82"
+        )
+        assert src.volumes[0 == 0], 100 * 1000 - 91 * 100
+        dst_exp = np.ones_like(dst.volumes) * 100
+        dst_exp[dst.indices["C04"]] = 0
+        dst_exp[dst.indices["C07"]] = 0
+        dst_exp[dst.indices["E09"]] = 0
+        dst_exp[dst.indices["F06"]] = 0
+        dst_exp[dst.indices["B11"]] = 0
+        np.testing.assert_array_equal(dst.volumes, dst_exp)
+        return
+
+    def test_oo_example_2(self) -> None:
+        src = Trough(
+            "T2",
+            8,
+            1,
+            min_volume=20,
+            max_volume=100 * 1000,
+            initial_volumes=100 * 1000,
+        )
+        dst = Labware("MTP-96-2", 8, 12, min_volume=20, max_volume=300)
+        with BaseWorklist() as wl:
+            wl.distribute(
+                src,
+                0,
+                dst,
+                dst.wells,
+                volume=100,
+                liquid_class="Water",
+                diti_reuse=2,
+                multi_disp=5,
+                direction="left_to_right",
+                src_rack_type="Trough 100ml",
+                dst_rack_type="96 Well Microplate",
+                label="Test Label",
+            )
+        assert wl[0] == "C;Test Label"
+        assert wl[1] == "R;T2;;Trough 100ml;1;8;MTP-96-2;;96 Well Microplate;1;96;100;Water;2;5;0"
+        assert src.volumes[0 == 0], 100 * 1000 - 96 * 100
+        np.testing.assert_array_equal(dst.volumes, np.ones_like(dst.volumes) * 100)
+        return
+
+    def test_oo_block_from_right(self) -> None:
+        src = Trough(
+            "Water",
+            8,
+            1,
+            min_volume=20,
+            max_volume=100 * 1000,
+            initial_volumes=100 * 1000,
+        )
+        dst = Labware("96mtp", 8, 12, min_volume=20, max_volume=300)
+        with BaseWorklist() as wl:
+            wl.distribute(
+                src,
+                0,
+                dst,
+                dst.wells[1:4, 2:7],
+                volume=50,
+                liquid_class="TestLC",
+                diti_reuse=10,
+                multi_disp=5,
+                direction="right_to_left",
+                label="Test Label",
+            )
+        assert wl[0] == "C;Test Label"
+        skip_pos = ";21;22;23;24;25;29;30;31;32;33;37;38;39;40;41;45;46;47;48;49"
+        assert wl[1] == f"R;Water;;;1;8;96mtp;;;18;52;50;TestLC;10;5;1{skip_pos}"
+        assert src.volumes[0 == 0], 100 * 1000 - 15 * 50
+        assert np.all(dst.volumes[1:4, 2:7] == 50)
+        return

--- a/robotools/worklists/test_utils.py
+++ b/robotools/worklists/test_utils.py
@@ -1,0 +1,39 @@
+import logging
+
+from robotools.liquidhandling.labware import Labware, Trough
+from robotools.worklists.utils import optimize_partition_by
+
+
+def test_automatic_partitioning(caplog) -> None:
+    S = Labware("S", 8, 2, min_volume=5000, max_volume=250 * 1000)
+    D = Labware("D", 8, 2, min_volume=5000, max_volume=250 * 1000)
+    ST = Trough("ST", 8, 2, min_volume=5000, max_volume=250 * 1000)
+    DT = Trough("DT", 8, 2, min_volume=5000, max_volume=250 * 1000)
+
+    # Expected behaviors:
+    # + always keep settings other than 'auto'
+    # + warn user about inefficient configuration (when user selects to partition by the trough)
+
+    # automatic
+    assert "source" == optimize_partition_by(S, D, "auto", "No troughs at all")
+    assert "source" == optimize_partition_by(S, DT, "auto", "Trough destination")
+    assert "destination" == optimize_partition_by(ST, D, "auto", "Trough source")
+    optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
+
+    # fixed to source
+    assert "source" == optimize_partition_by(S, D, "source", "No troughs at all")
+    assert "source" == optimize_partition_by(S, DT, "source", "Trough destination")
+    with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
+        assert "source" == optimize_partition_by(ST, D, "source", "Trough source")
+    assert 'Consider using partition_by="destination"' in caplog.records[0].message
+    optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
+
+    # fixed to destination
+    optimize_partition_by(S, D, "destination", "No troughs at all") == "destination"
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="robotools.evotools"):
+        assert optimize_partition_by(S, DT, "destination", "Trough destination") == "destination"
+    assert 'Consider using partition_by="source"' in caplog.records[0].message
+    assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
+    assert optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
+    return

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -6,8 +6,8 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy
 
-from robotools.evotools.exceptions import InvalidOperationError
 from robotools.evotools.types import Tip, int_to_tip
+from robotools.worklists.exceptions import InvalidOperationError
 
 from .. import liquidhandling
 


### PR DESCRIPTION
* :truck: This moves methods to `EvoWorklist` which should not have been located in `BaseWorklist` to begin with.
* :truck: Also merges definitions of `InvalidOperationError` and `CompatibilityError` into `robotools.worklists.exceptions`.
* 🚚 Splits & moves the tests to align with the new structure, and to avoid deprecation warnings.
* 🛡️ Added tests to cover `EvoWorklist.evo_*` commands.