### PR TITLE
Refactor how well position numbers are calculate to be Fluent-trough compatible

### DIFF
--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -14,7 +14,7 @@ from .transform import (
 from .utils import DilutionPlan, get_trough_wells
 from .worklists import BaseWorklist, CompatibilityError
 
-__version__ = "1.9.1"
+__version__ = "1.10.0"
 __all__ = (
     "BaseWorklist",
     "CompatibilityError",

--- a/robotools/evotools/__init__.py
+++ b/robotools/evotools/__init__.py
@@ -1,3 +1,4 @@
 from robotools.evotools.types import Labwares, Tip, int_to_tip
+from robotools.evotools.utils import get_well_position
 from robotools.evotools.worklist import EvoWorklist, Worklist
 from robotools.worklists.exceptions import InvalidOperationError

--- a/robotools/evotools/test_utils.py
+++ b/robotools/evotools/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from robotools import Labware, Trough
+from robotools.evotools import utils
+
+
+def test_get_well_position():
+    plate = Labware("plate", 3, 4, min_volume=0, max_volume=50)
+    assert utils.get_well_position(plate, "A01") == 1
+    assert utils.get_well_position(plate, "B01") == 2
+    assert utils.get_well_position(plate, "B04") == 11
+
+    trough = Trough("trough", 2, 3, min_volume=0, max_volume=50)
+    assert utils.get_well_position(trough, "A01") == 1
+    assert utils.get_well_position(trough, "B01") == 2
+    assert utils.get_well_position(trough, "A02") == 3
+    assert utils.get_well_position(trough, "A03") == 5
+
+    with pytest.raises(ValueError, match="not an alphanumeric well ID"):
+        utils.get_well_position(trough, "A-3")
+
+    # Currently not implemented at the Labware level:
+    # megaplate = Labware("mplate", 50, 3, min_volume=0, max_volume=50)
+    # assert utils.get_well_position(megaplate, "AA2") == 51
+    pass

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -590,6 +590,45 @@ class TestEvoWorklist:
         return
 
 
+class TestTroughLabwareWorklist:
+    def test_aspirate(self) -> None:
+        source = Trough(
+            "SourceLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200
+        )
+        with EvoWorklist() as wl:
+            wl.aspirate(source, ["A01", "A02", "C02"], 50)
+            wl.aspirate(source, ["A01", "A02", "C02"], [1, 2, 3])
+            assert wl == [
+                "A;SourceLW;;;1;;50.00;;;;",
+                "A;SourceLW;;;4;;50.00;;;;",
+                "A;SourceLW;;;6;;50.00;;;;",
+                "A;SourceLW;;;1;;1.00;;;;",
+                "A;SourceLW;;;4;;2.00;;;;",
+                "A;SourceLW;;;6;;3.00;;;;",
+            ]
+            np.testing.assert_array_equal(source.volumes, [[149, 95, 200]])
+            assert len(source.history) == 3
+        return
+
+    def test_dispense(self) -> None:
+        destination = Trough("DestinationLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200)
+        with EvoWorklist() as wl:
+            wl.dispense(destination, ["A01", "A02", "A03", "B01"], 50)
+            wl.dispense(destination, ["A01", "A02", "C02"], [1, 2, 3])
+            assert wl == [
+                "D;DestinationLW;;;1;;50.00;;;;",
+                "D;DestinationLW;;;4;;50.00;;;;",
+                "D;DestinationLW;;;7;;50.00;;;;",
+                "D;DestinationLW;;;2;;50.00;;;;",
+                "D;DestinationLW;;;1;;1.00;;;;",
+                "D;DestinationLW;;;4;;2.00;;;;",
+                "D;DestinationLW;;;6;;3.00;;;;",
+            ]
+            np.testing.assert_array_equal(destination.volumes, [[101, 55, 50]])
+            assert len(destination.history) == 3
+        return
+
+
 class TestEvoCommands:
     def test_evo_aspirate(self) -> None:
         lw = Labware("A", 4, 5, min_volume=10, max_volume=100)

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -10,6 +10,7 @@ import numpy as np
 from robotools import liquidhandling
 from robotools.evotools import commands
 from robotools.evotools.types import Tip
+from robotools.evotools.utils import get_well_position
 from robotools.worklists.base import BaseWorklist
 from robotools.worklists.utils import (
     optimize_partition_by,
@@ -24,6 +25,9 @@ logger = logging.getLogger(__name__)
 
 class EvoWorklist(BaseWorklist):
     """Context manager for the creation of Tecan EVO worklists."""
+
+    def _get_well_position(self, labware: liquidhandling.Labware, well: str) -> int:
+        return get_well_position(labware, well)
 
     def evo_aspirate(
         self,

--- a/robotools/fluenttools/__init__.py
+++ b/robotools/fluenttools/__init__.py
@@ -1,1 +1,2 @@
+from robotools.fluenttools.utils import get_well_position
 from robotools.fluenttools.worklist import FluentWorklist

--- a/robotools/fluenttools/test_utils.py
+++ b/robotools/fluenttools/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from robotools import Labware, Trough
+from robotools.fluenttools import utils
+
+
+def test_get_well_position():
+    plate = Labware("plate", 3, 4, min_volume=0, max_volume=50)
+    assert utils.get_well_position(plate, "A01") == 1
+    assert utils.get_well_position(plate, "B01") == 2
+    assert utils.get_well_position(plate, "B04") == 11
+
+    trough = Trough("trough", 2, 3, min_volume=0, max_volume=50)
+    assert utils.get_well_position(trough, "A01") == 1
+    assert utils.get_well_position(trough, "B01") == 1
+    assert utils.get_well_position(trough, "A02") == 2
+    assert utils.get_well_position(trough, "A03") == 3
+
+    with pytest.raises(ValueError, match="not an alphanumeric well ID"):
+        utils.get_well_position(trough, "🧨")
+
+    # Currently not implemented at the Labware level:
+    # megaplate = Labware("mplate", 50, 3, min_volume=0, max_volume=50)
+    # assert utils.get_well_position(megaplate, "AA2") == 51
+    pass

--- a/robotools/fluenttools/utils.py
+++ b/robotools/fluenttools/utils.py
@@ -3,20 +3,6 @@ import re
 
 from robotools.liquidhandling import Labware
 
-
-def to_hex(dec: int):
-    """Method from stackoverflow to convert decimal to hex.
-    Link: https://stackoverflow.com/questions/5796238/python-convert-decimal-to-hex
-    Solution posted by user "Chunghee Kim" on 21.11.2020.
-    """
-    digits = "0123456789ABCDEF"
-    x = dec % 16
-    rest = dec // 16
-    if rest == 0:
-        return digits[x]
-    return to_hex(rest) + digits[x]
-
-
 _WELLID_MATCHER = re.compile(r"^([a-zA-Z]+?)(\d+?)$")
 """Compiled RegEx for matching well row & column from alphanumeric IDs."""
 
@@ -30,11 +16,13 @@ def get_well_position(labware: Labware, well: str) -> int:
     row = m.group(1)
     column = int(m.group(2))
 
-    r = labware.row_ids.index(row)
     c = labware.column_ids.index(column)
 
-    # Calculate the position from the row & column number.
-    # The EVO counts virtual rows in troughs too.
-    if labware.virtual_rows is not None:
-        return 1 + c * labware.virtual_rows + r
+    # The Fluent does NOT count rows inside troughs!
+    if labware.is_trough:
+        return 1 + c
+
+    # Therefore the row number is only relevant for non-trough labware.
+    row = well[0]
+    r = labware.row_ids.index(row)
     return 1 + c * labware.n_rows + r

--- a/robotools/fluenttools/worklist.py
+++ b/robotools/fluenttools/worklist.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import numpy as np
 
+from robotools.fluenttools.utils import get_well_position
 from robotools.liquidhandling.labware import Labware
 from robotools.worklists.base import BaseWorklist
 from robotools.worklists.utils import (
@@ -25,6 +26,9 @@ class FluentWorklist(BaseWorklist):
         auto_split: bool = True,
     ) -> None:
         super().__init__(filepath, max_volume, auto_split)
+
+    def _get_well_position(self, labware: Labware, well: str) -> int:
+        return get_well_position(labware, well)
 
     def transfer(
         self,

--- a/robotools/liquidhandling/labware.py
+++ b/robotools/liquidhandling/labware.py
@@ -54,6 +54,12 @@ class Labware:
     @property
     def positions(self) -> Dict[str, int]:
         """Mapping of well-ids to EVOware-compatible position numbers."""
+        warnings.warn(
+            "`Labware.positions` is deprecated in favor of model-specific implementations."
+            "Use `robotools.evotools.get_well_positions()` or `robotools.fluenttools.get_well_positions()`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._positions
 
     @property

--- a/robotools/liquidhandling/labware.py
+++ b/robotools/liquidhandling/labware.py
@@ -56,7 +56,7 @@ class Labware:
         """Mapping of well-ids to EVOware-compatible position numbers."""
         warnings.warn(
             "`Labware.positions` is deprecated in favor of model-specific implementations."
-            "Use `robotools.evotools.get_well_positions()` or `robotools.fluenttools.get_well_positions()`.",
+            " Use `robotools.evotools.get_well_positions()` or `robotools.fluenttools.get_well_positions()`.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/robotools/liquidhandling/test_labware.py
+++ b/robotools/liquidhandling/test_labware.py
@@ -32,14 +32,15 @@ class TestStandardLabware:
             "B03": (1, 2),
         }
         assert plate.indices == exp
-        assert plate.positions == {
-            "A01": 1,
-            "A02": 3,
-            "A03": 5,
-            "B01": 2,
-            "B02": 4,
-            "B03": 6,
-        }
+        with pytest.warns(DeprecationWarning, match="in favor of model-specific"):
+            assert plate.positions == {
+                "A01": 1,
+                "A02": 3,
+                "A03": 5,
+                "B01": 2,
+                "B02": 4,
+                "B03": 6,
+            }
         return
 
     def test_invalid_init(self) -> None:
@@ -215,28 +216,29 @@ class TestTroughLabware:
             "E03": (0, 2),
             "E04": (0, 3),
         }
-        assert trough.positions == {
-            "A01": 1,
-            "A02": 6,
-            "A03": 11,
-            "A04": 16,
-            "B01": 2,
-            "B02": 7,
-            "B03": 12,
-            "B04": 17,
-            "C01": 3,
-            "C02": 8,
-            "C03": 13,
-            "C04": 18,
-            "D01": 4,
-            "D02": 9,
-            "D03": 14,
-            "D04": 19,
-            "E01": 5,
-            "E02": 10,
-            "E03": 15,
-            "E04": 20,
-        }
+        with pytest.warns(DeprecationWarning, match="in favor of model-specific"):
+            assert trough.positions == {
+                "A01": 1,
+                "A02": 6,
+                "A03": 11,
+                "A04": 16,
+                "B01": 2,
+                "B02": 7,
+                "B03": 12,
+                "B04": 17,
+                "C01": 3,
+                "C02": 8,
+                "C03": 13,
+                "C04": 18,
+                "D01": 4,
+                "D02": 9,
+                "D03": 14,
+                "D04": 19,
+                "E01": 5,
+                "E02": 10,
+                "E03": 15,
+                "E04": 20,
+            }
         return
 
     def test_initial_volumes(self) -> None:

--- a/robotools/worklists/test_base.py
+++ b/robotools/worklists/test_base.py
@@ -505,45 +505,6 @@ class TestStandardLabwareWorklist:
         pass
 
 
-class TestTroughLabwareWorklist:
-    def test_aspirate(self) -> None:
-        source = Trough(
-            "SourceLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200, initial_volumes=200
-        )
-        with BaseWorklist() as wl:
-            wl.aspirate(source, ["A01", "A02", "C02"], 50)
-            wl.aspirate(source, ["A01", "A02", "C02"], [1, 2, 3])
-            assert wl == [
-                "A;SourceLW;;;1;;50.00;;;;",
-                "A;SourceLW;;;4;;50.00;;;;",
-                "A;SourceLW;;;6;;50.00;;;;",
-                "A;SourceLW;;;1;;1.00;;;;",
-                "A;SourceLW;;;4;;2.00;;;;",
-                "A;SourceLW;;;6;;3.00;;;;",
-            ]
-            np.testing.assert_array_equal(source.volumes, [[149, 95, 200]])
-            assert len(source.history) == 3
-        return
-
-    def test_dispense(self) -> None:
-        destination = Trough("DestinationLW", virtual_rows=3, columns=3, min_volume=10, max_volume=200)
-        with BaseWorklist() as wl:
-            wl.dispense(destination, ["A01", "A02", "A03", "B01"], 50)
-            wl.dispense(destination, ["A01", "A02", "C02"], [1, 2, 3])
-            assert wl == [
-                "D;DestinationLW;;;1;;50.00;;;;",
-                "D;DestinationLW;;;4;;50.00;;;;",
-                "D;DestinationLW;;;7;;50.00;;;;",
-                "D;DestinationLW;;;2;;50.00;;;;",
-                "D;DestinationLW;;;1;;1.00;;;;",
-                "D;DestinationLW;;;4;;2.00;;;;",
-                "D;DestinationLW;;;6;;3.00;;;;",
-            ]
-            np.testing.assert_array_equal(destination.volumes, [[101, 55, 50]])
-            assert len(destination.history) == 3
-        return
-
-
 class TestLargeVolumeHandling:
     def testpartition_volume_helper(self) -> None:
         assert [] == partition_volume(0, max_volume=950)

--- a/robotools/worklists/test_base.py
+++ b/robotools/worklists/test_base.py
@@ -574,14 +574,6 @@ class TestLargeVolumeHandling:
             max_volume=100 * 1000,
             initial_volumes=50 * 1000,
         )
-        destination = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
         with BaseWorklist(max_volume=900, auto_split=False) as wl:
             with pytest.raises(InvalidOperationError):
                 wl.aspirate_well("WaterTrough", 1, 1000)
@@ -593,14 +585,6 @@ class TestLargeVolumeHandling:
                 wl.dispense(source, ["A01", "A02", "C02"], 1000)
 
         source = Trough(
-            "WaterTrough",
-            virtual_rows=3,
-            columns=3,
-            min_volume=1000,
-            max_volume=100 * 1000,
-            initial_volumes=50 * 1000,
-        )
-        destination = Trough(
             "WaterTrough",
             virtual_rows=3,
             columns=3,


### PR DESCRIPTION
This refactors how well position numbers are calculated and accessed, such that cross-compatibility between Tecan EVO and Tecan Fluent is maximized.

# Problem

On the EVO, troughs have "virtual rows" that count into the Fortran-style well numbering.

On the Fluent, all wells in the same column are addressed by the column number.

Previously, `Labware(...).positions` was the lookup-dictionary encoding this information within robotools.
However, the construction of `Trough(...)` or `Labware(...)` is not specific to the EVO vs. Fluent, and such a dependency should not be introduced.

# Solution

New functions are introduced to facilitate Tecan model-specific calculation of well position numbers:
* `evotools.get_well_position`
* `fluenttools.get_well_position`

The `aspirate`/`dispense`/`distribute` commands in `BaseWorklist` is modified to use a new, private method `self._get_well_position` instead of `Labware().positions`.
* This new method must be implemented by `EvoWorklist`/`FluentWorklist` which route the call to the aforementioned functions.
* `._get_well_position` is __not__ marked abstract because some other `BaseWorklist` methods remain usable even without instances of model-specific worklist.
* `._get_well_position` raises an informative `TypeError` instructing the user to use `EvoWorklist`/`FluentWorklist` for model-specific operations.

# Changes
* 🧹 Some unused test code was deleted.
* 🚚 Some `BaseWorklist` tests were moved, because they are in fact `EvoWorklist`-specific.
* 🔧  New functions, methods and refactoring as described above.
* ⚠️ `Labware.positions` was deprecated and emits a `DeprecationWarning` when used.
* ℹ️ The value of `Trough(..., virtual_rows=...)` will not be relevant for operations in `FluentWorklist` moving forward.