### PR TITLE
Add feature to enable using W; as a wash scheme -  needed for DiTi evos.

### DIFF
--- a/robotools/worklists/base.py
+++ b/robotools/worklists/base.py
@@ -113,9 +113,12 @@ class BaseWorklist(list):
         scheme : int
             Number indicating the wash scheme (default: 1)
         """
-        if not scheme in {1, 2, 3, 4}:
-            raise ValueError("scheme must be either 1, 2, 3 or 4")
-        self.append(f"W{scheme};")
+        if not scheme in {0, 1, 2, 3, 4}:
+            raise ValueError("scheme must be either 0, 1, 2, 3 or 4")
+        if scheme == 0:
+            self.append("W;")
+        else:
+            self.append(f"W{scheme};")
         return
 
     def decontaminate(self) -> None:


### PR DESCRIPTION
As discussed in the open issue, this is a change to enable using the right wash scheme for diti evos that strictly require an "W;" as a wash scheme and do not cope with "W1;" or any other number. 
Question: Do you bump the version number manually or automatically for the pypi build? 
