### PR TITLE
Align `wash_scheme=None` signature and insert `W;` in Evo case

### DIFF
--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -20,7 +20,7 @@ from .transform import (
 from .utils import DilutionPlan, get_trough_wells
 from .worklists import BaseWorklist, CompatibilityError
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 __all__ = (
     "BaseWorklist",
     "CompatibilityError",

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -104,7 +104,7 @@ class TestEvoWorklist:
                         [15.3, 17.53],
                     ]
                 ),
-                wash_scheme=None,
+                wash_scheme="reuse",
             )
             assert wl == [
                 "A;A;;;1;;20.00;;;;",

--- a/robotools/fluenttools/test_worklist.py
+++ b/robotools/fluenttools/test_worklist.py
@@ -38,7 +38,7 @@ class TestFluentWorklist:
     def test_transfer_flush(self):
         A = Labware("A", 3, 4, min_volume=10, max_volume=200, initial_volumes=150)
         with FluentWorklist() as wl:
-            wl.transfer(A, "A01", A, "B01", 20, wash_scheme=None)
+            wl.transfer(A, "A01", A, "B01", 20, wash_scheme="flush")
         assert len(wl) == 3
         assert wl[-1] == "F;"
         pass

--- a/robotools/fluenttools/worklist.py
+++ b/robotools/fluenttools/worklist.py
@@ -1,6 +1,7 @@
+import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 
@@ -39,7 +40,7 @@ class FluentWorklist(BaseWorklist):
         volumes: Union[float, Sequence[float], np.ndarray],
         *,
         label: Optional[str] = None,
-        wash_scheme: Optional[int] = 1,
+        wash_scheme: Literal[1, 2, 3, 4, "flush", "reuse"] = 1,
         partition_by: str = "auto",
         **kwargs,
     ) -> None:
@@ -60,8 +61,12 @@ class FluentWorklist(BaseWorklist):
         label
             Label of the operation to log into labware history
         wash_scheme
-            Wash scheme to apply after every tip use.
-            If ``None``, only a flush is inserted instead of a wash.
+            - One of ``{1, 2, 3, 4}`` to select a wash scheme for fixed tips,
+            or drop tips when using DiTis.
+            - ``"flush"`` blows out tips, but does not drop DiTis, and only does a short wash with fixed tips.
+            - ``"reuse"`` continues pipetting without flushing, dropping or washing.
+            Passing ``None`` is deprecated, results in ``"flush"`` behavior and emits a warning.
+
         partition_by : str
             one of 'auto' (default), 'source' or 'destination'
                 'auto': partitioning by source unless the source is a Trough
@@ -77,6 +82,13 @@ class FluentWorklist(BaseWorklist):
         destination_wells = np.array(destination_wells).flatten("F")
         volumes = np.array(volumes).flatten("F")
         nmax = max((len(source_wells), len(destination_wells), len(volumes)))
+
+        # Deal with deprecated behavior
+        if wash_scheme is None:
+            warnings.warn(
+                "wash_scheme=None is deprecated. For flushing pass 'flush'.", DeprecationWarning, stacklevel=2
+            )
+            wash_scheme = "flush"
 
         if len(source_wells) == 1:
             source_wells = np.repeat(source_wells, nmax)
@@ -124,10 +136,12 @@ class FluentWorklist(BaseWorklist):
                                 **kwargs,
                             )
                             nsteps += 1
-                            if wash_scheme is not None:
-                                self.wash(scheme=wash_scheme)
-                            else:
+                            if wash_scheme == "flush":
                                 self.flush()
+                            elif wash_scheme == "reuse":
+                                pass
+                            else:
+                                self.wash(scheme=wash_scheme)
                             naccessed += 1
                 # LVH: if multiple wells are accessed, don't group across partitions
                 if npartitions > 1 and naccessed > 1 and not p == npartitions - 1:

--- a/robotools/fluenttools/worklist.py
+++ b/robotools/fluenttools/worklist.py
@@ -25,8 +25,9 @@ class FluentWorklist(BaseWorklist):
         filepath: Optional[Union[str, Path]] = None,
         max_volume: Union[int, float] = 950,
         auto_split: bool = True,
+        diti_mode: bool = False,
     ) -> None:
-        super().__init__(filepath, max_volume, auto_split)
+        super().__init__(filepath, max_volume, auto_split, diti_mode)
 
     def _get_well_position(self, labware: Labware, well: str) -> int:
         return get_well_position(labware, well)

--- a/robotools/utils.py
+++ b/robotools/utils.py
@@ -1,6 +1,6 @@
 """Module with robot-agnostic utilities."""
 import collections
-from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Iterable, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy
 
@@ -178,7 +178,7 @@ class DilutionPlan:
         pre_mix_hook: Optional[Callable[[int, BaseWorklist], Optional[BaseWorklist]]] = None,
         post_mix_hook: Optional[Callable[[int, BaseWorklist], Optional[BaseWorklist]]] = None,
         mix_threshold: float = 0.05,
-        mix_wash: int = 2,
+        mix_wash: Literal[1, 2, 3, 4, "flush", "reuse"] = 2,
         mix_repeat: int = 2,
         mix_volume: float = 0.8,
         lc_stock_trough: str = "Trough_Water_FD_AspLLT",
@@ -235,9 +235,9 @@ class DilutionPlan:
             to multiple destinations.
         mix_threshold : float
             Maximum fraction of total dilution volume (self.vmax) that may be diluted without subsequent mixing (defaults to 0.05 or 5%)
-        mix_wash : int
-            Number of the wash scheme inbetween mixing steps
-            The recommended wash scheme is 0 mL + 1 mL with fast wash.
+        mix_wash
+            Transfer wash scheme inbetween mixing steps.
+            The recommended wash scheme is 0 mL + 1 mL with fast wash, or ``"flush"``.
         mix_repeat : int
             How often to mix after diluting.
             May be set to 0, particularly when combined with a `pre_mix_hook`.

--- a/robotools/worklists/base.py
+++ b/robotools/worklists/base.py
@@ -3,7 +3,7 @@
 import logging
 import math
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Union
+from typing import Dict, Iterable, List, Literal, Optional, Sequence, Union
 
 import numpy
 
@@ -516,7 +516,7 @@ class BaseWorklist(list):
         volumes: Union[float, Sequence[float], numpy.ndarray],
         *,
         label: Optional[str] = None,
-        wash_scheme: int = 1,
+        wash_scheme: Literal[1, 2, 3, 4, "flush", "reuse"] = 1,
         partition_by: str = "auto",
         **kwargs,
     ):

--- a/robotools/worklists/test_base.py
+++ b/robotools/worklists/test_base.py
@@ -201,6 +201,14 @@ class TestWorklist:
                 "W4;",
             ]
             assert wl == exp
+
+        with BaseWorklist(diti_mode=True) as wl:
+            wl.wash()
+            wl.wash(3)
+            assert wl == [
+                "W;",
+                "W;",
+            ]
         return
 
     @pytest.mark.parametrize("cls", [EvoWorklist, FluentWorklist])
@@ -233,12 +241,21 @@ class TestWorklist:
                     assert wl[-1] == "F;"
                 else:
                     raise NotImplementedError()
+
+        # In DiTi mode, any numeric wash scheme results in "W;"
+        with cls(diti_mode=True) as wl:
+            wl.transfer(A, "A01", A, "A01", 25, wash_scheme=2)
+            assert wl[-1] == "W;"
         pass
 
     def test_decontaminate(self) -> None:
         with BaseWorklist() as wl:
             wl.decontaminate()
             assert wl == ["WD;"]
+
+        with BaseWorklist(diti_mode=True) as wl:
+            with pytest.raises(InvalidOperationError, match="not available"):
+                wl.decontaminate()
         return
 
     def test_flush(self) -> None:


### PR DESCRIPTION
* 🐛 Fixes the `transfer` method signatures to align between `BaseWorklist`, `EvoWorklist`, `FluentWorklist`.
* ✨ New `Worklist(diti_mode=True|False)` was introduced to switch to `W;`-only wash schemes when using DiTis (closes #77)
* ✨ `transfer(wash_scheme=...)` options changed such that:
  * One of ``{1, 2, 3, 4}`` selects a wash scheme for fixed tips, or drops tips when using DiTis.
  * ``"flush"`` blows out tips, but does not drop DiTis, and only does a short wash with fixed tips.
  * ``"reuse"`` continues pipetting without flushing, dropping or washing.
  * Passing `wash_scheme=None` is deprecated, because it resulted in "flush" for Fluent and "reuse" for EVO worklists.

Replaces #78