### PR TITLE
Optimize partitioning to make pipetting from troughs more efficient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotools"
-version = "1.11.4"
+version = "1.12.0"
 description = "Pythonic in-silico liquid handling and creation of Tecan FreedomEVO worklists."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/robotools/worklists/test_utils.py
+++ b/robotools/worklists/test_utils.py
@@ -17,7 +17,7 @@ def test_automatic_partitioning(caplog) -> None:
     # automatic
     assert "source" == optimize_partition_by(S, D, "auto", "No troughs at all")
     assert "source" == optimize_partition_by(S, DT, "auto", "Trough destination")
-    assert "destination" == optimize_partition_by(ST, D, "auto", "Trough source")
+    assert "source" == optimize_partition_by(ST, D, "auto", "Trough source")
     optimize_partition_by(ST, DT, "auto", "Trough source and destination") == "source"
 
     # fixed to source

--- a/robotools/worklists/test_utils.py
+++ b/robotools/worklists/test_utils.py
@@ -1,7 +1,21 @@
 import logging
 
 from robotools.liquidhandling.labware import Labware, Trough
-from robotools.worklists.utils import optimize_partition_by
+from robotools.worklists.utils import (
+    non_repetitive_argsort,
+    optimize_partition_by,
+    partition_by_column,
+)
+
+
+def test_non_repetitive_argsort():
+    wells = "A01,C01,B01,B01,A01,B01".split(",")
+    result = non_repetitive_argsort(wells)
+    assert isinstance(result, list)
+    assert all(isinstance(r, int) for r in result)
+    assert len(result) == len(wells)
+    assert result == [0, 2, 1, 4, 3, 5]
+    pass
 
 
 def test_automatic_partitioning(caplog) -> None:
@@ -37,3 +51,21 @@ def test_automatic_partitioning(caplog) -> None:
     assert optimize_partition_by(ST, D, "destination", "Trough source") == "destination"
     assert optimize_partition_by(ST, DT, "destination", "Trough source and destination") == "destination"
     return
+
+
+def test_partition_by_column_does_not_repeat_wells():
+    wells = "C01,B01,A01,B01,A01,C01,D02,C02".split(",")
+    cgroups = partition_by_column(
+        sources=wells,
+        destinations=["A01"] * 8,
+        volumes=[1, 2, 3, 4, 5, 6, 7, 8],
+        partition_by="source",
+    )
+    assert len(cgroups) == 2
+    assert cgroups[0][0] == "A01,B01,C01,A01,B01,C01".split(",")
+    assert cgroups[0][1] == ["A01"] * 6
+    assert cgroups[0][2] == [3, 2, 1, 5, 4, 6]
+    assert cgroups[1][0] == "C02,D02".split(",")
+    assert cgroups[1][1] == ["A01"] * 2
+    assert cgroups[1][2] == [8, 7]
+    pass

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -169,10 +169,7 @@ def optimize_partition_by(
         raise ValueError(f"Invalid partition_by argument: {partition_by}")
     # automatic partitioning decision
     if partition_by == "auto":
-        if source.is_trough and not destination.is_trough:
-            partition_by = "destination"
-        else:
-            partition_by = "source"
+        partition_by = "source"
     else:
         # log warnings about potentially inefficient partitioning settings
         if partition_by == "source" and source.is_trough and not destination.is_trough:

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -151,7 +151,18 @@ def optimize_partition_by(
 ) -> Literal["source", "destination"]:
     """Determines optimal partitioning settings.
 
+
     Parameters
+    ----------
+    source
+        Source labware object.
+    destination
+        Destination labware object.
+    partition_by
+        User-provided partitioning settings.
+    label
+        Label of the operation (optional).
+
     ----------
     source (Labware): source labware object
     destination (Labware): destination labware object

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -174,17 +174,23 @@ def optimize_partition_by(
     if partition_by == "source":
         if source.is_trough and not destination.is_trough:
             logger.warning(
-                f'Partitioning by "source" ({source.name}), which is a Trough while destination ({destination.name}) is not a Trough.'
+                'Partitioning by "source" (%s), which is a Trough while destination (%s) is not a Trough.'
                 ' This is potentially inefficient. Consider using partition_by="destination".'
-                f" (label={label})"
+                " (label=%s)",
+                source.name,
+                destination.name,
+                label,
             )
         return "source"
     elif partition_by == "destination":
         if destination.is_trough and not source.is_trough:
             logger.warning(
-                f'Partitioning by "destination" ({destination.name}), which is a Trough while source ({source.name}) is not a Trough.'
+                'Partitioning by "destination" (%s), which is a Trough while source (%s) is not a Trough.'
                 ' This is potentially inefficient. Consider using partition_by="source"'
-                f" (label={label})"
+                " (label=%s)",
+                destination.name,
+                source.name,
+                label,
             )
         return "destination"
     raise ValueError(f"Invalid partition_by argument: {partition_by}")

--- a/robotools/worklists/utils.py
+++ b/robotools/worklists/utils.py
@@ -2,7 +2,7 @@
 import collections
 import logging
 import math
-from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy
 
@@ -216,6 +216,27 @@ def partition_volume(volume: float, *, max_volume: Union[int, float]) -> List[fl
     return volumes
 
 
+def non_repetitive_argsort(wells: Sequence[str]) -> list[int]:
+    """Argsort without repeating items with the same first letter."""
+    # Group wells by row
+    by_row = collections.defaultdict(list)
+    for iw, w in enumerate(wells):
+        by_row[w[0]].append((iw, w))
+    by_row_sorted = {r: by_row[r] for r in sorted(by_row)}
+
+    # Collect the original index of the first entry
+    # from each row, until all rows are empty.
+    results = []
+    while by_row_sorted:
+        for r in list(by_row_sorted):
+            row = by_row_sorted[r]
+            iw, w = row.pop(0)
+            results.append(iw)
+            if not row:
+                by_row_sorted.pop(r)
+    return results
+
+
 def partition_by_column(
     sources: Iterable[str],
     destinations: Iterable[str],
@@ -259,9 +280,9 @@ def partition_by_column(
     # sort the rows within the column
     for c, (srcs, dsts, vols) in enumerate(column_groups):
         if partition_by == "source":
-            order = numpy.argsort(srcs)
+            order = non_repetitive_argsort(srcs)
         elif partition_by == "destination":
-            order = numpy.argsort(dsts)
+            order = non_repetitive_argsort(dsts)
         else:
             raise ValueError(f'Invalid `partition_by` parameter "{partition_by}""')
         column_groups[c] = (


### PR DESCRIPTION
* ⚠️ Default `partition_by="auto"` to `"source"` (only trough sources defaulted to `"destination"` before).
* 🤯 Sort wells like `A01,B01,A01,B01` instead of `A01,A01,B01,B01` when partitioning. This increases efficiency in common trough-pipetting situations.
* ⚙️ Type hinting and code style improvements.