### PR TITLE
Add `on_underflow` option to enable ignoring or just warning about volume underflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
+    "typing_extensions",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robotools"
-version = "1.12.0"
+version = "1.13.0"
 description = "Pythonic in-silico liquid handling and creation of Tecan FreedomEVO worklists."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -15,8 +15,6 @@ authors = [
 classifiers = [
     "Programming Language :: Python",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/robotools/__init__.py
+++ b/robotools/__init__.py
@@ -10,7 +10,9 @@ from .liquidhandling import (
     Trough,
     VolumeOverflowError,
     VolumeUnderflowError,
+    VolumeUnderflowWarning,
     VolumeViolationException,
+    VolumeViolationWarning,
 )
 from .transform import (
     WellRandomizer,

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -3,6 +3,10 @@ import pytest
 
 from robotools.evotools import EvoWorklist, Labwares
 from robotools.evotools.types import Tip
+from robotools.liquidhandling.exceptions import (
+    VolumeUnderflowError,
+    VolumeUnderflowWarning,
+)
 from robotools.liquidhandling.labware import Labware, Trough
 from robotools.worklists.exceptions import InvalidOperationError
 
@@ -588,6 +592,19 @@ class TestEvoWorklist:
             ],
         )
         return
+
+    def test_transfer_on_underflow(self):
+        A = Labware("A", 3, 2, min_volume=100, max_volume=2000, initial_volumes=500)
+        with EvoWorklist() as wl:
+            wl.transfer(A, "A01", A, "A02", 600, on_underflow="debug")
+            assert A.volumes[0, 0] == 100
+            assert A.volumes[0, 1] == 1100
+            with pytest.warns(VolumeUnderflowWarning, match="500.0 - 600.0 < 100"):
+                wl.transfer(A, "B01", A, "B02", 600, on_underflow="warn")
+                assert A.volumes[1, 0] == 100
+                assert A.volumes[1, 1] == 1100
+            with pytest.raises(VolumeUnderflowError, match="500.0 - 600.0 < 100"):
+                wl.transfer(A, "C01", A, "C02", 600, on_underflow="raise")
 
 
 class TestTroughLabwareWorklist:

--- a/robotools/evotools/test_worklist.py
+++ b/robotools/evotools/test_worklist.py
@@ -639,12 +639,14 @@ class TestEvoCommands:
                 "A01",
                 labware_position=(30, 2),
                 tips=[Tip.T2],
-                volumes=20,
+                volumes=200,
                 liquid_class="PowerSuck",
+                on_underflow="debug",
             )
         assert len(wl) == 1
         assert "B;Aspirate" in wl[0]
-        assert lw.volumes[0, 0] == 30
+        # Underflow ignored, minimum volume remains
+        assert lw.volumes[0, 0] == 10
         pass
 
     def test_evo_dispense(self) -> None:

--- a/robotools/evotools/worklist.py
+++ b/robotools/evotools/worklist.py
@@ -230,6 +230,7 @@ class EvoWorklist(BaseWorklist):
         label: Optional[str] = None,
         wash_scheme: Literal[1, 2, 3, 4, "flush", "reuse"] = 1,
         partition_by: str = "auto",
+        on_underflow: Literal["debug", "warn", "raise"] = "raise",
         **kwargs,
     ) -> None:
         """Transfer operation between two labwares.
@@ -260,6 +261,14 @@ class EvoWorklist(BaseWorklist):
                 'auto': partitioning by source unless the source is a Trough
                 'source': partitioning by source columns
                 'destination': partitioning by destination columns
+        on_underflow
+            What to do about volume underflows (going below ``vmin``) in non-empty wells.
+
+            Options:
+
+            - ``"debug"`` mentions the underflowing wells in a log message at DEBUG level.
+            - ``"warn"`` emits an :class:`~robotools.liquidhandling.exceptions.VolumeUnderflowWarning`. This `can be captured in unit tests <https://docs.pytest.org/en/stable/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests>`_.
+            - ``"raise"`` raises a :class:`~robotools.liquidhandling.exceptions.VolumeUnderflowError` about underflowing wells.
         kwargs
             Additional keyword arguments to pass to aspirate and dispense.
             Most prominent example: `liquid_class`.
@@ -317,7 +326,7 @@ class EvoWorklist(BaseWorklist):
                     if len(vs) > p:
                         v = vs[p]
                         if v > 0:
-                            self.aspirate(source, s, v, label=None, **kwargs)
+                            self.aspirate(source, s, v, label=None, on_underflow=on_underflow, **kwargs)
                             self.dispense(
                                 destination,
                                 d,

--- a/robotools/fluenttools/worklist.py
+++ b/robotools/fluenttools/worklist.py
@@ -43,6 +43,7 @@ class FluentWorklist(BaseWorklist):
         label: Optional[str] = None,
         wash_scheme: Literal[1, 2, 3, 4, "flush", "reuse"] = 1,
         partition_by: str = "auto",
+        on_underflow: Literal["debug", "warn", "raise"] = "raise",
         **kwargs,
     ) -> None:
         """Transfer operation between two labwares.
@@ -73,6 +74,14 @@ class FluentWorklist(BaseWorklist):
                 'auto': partitioning by source unless the source is a Trough
                 'source': partitioning by source columns
                 'destination': partitioning by destination columns
+        on_underflow
+            What to do about volume underflows (going below ``vmin``) in non-empty wells.
+
+            Options:
+
+            - ``"debug"`` mentions the underflowing wells in a log message at DEBUG level.
+            - ``"warn"`` emits an :class:`~robotools.liquidhandling.exceptions.VolumeUnderflowWarning`. This `can be captured in unit tests <https://docs.pytest.org/en/stable/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests>`_.
+            - ``"raise"`` raises a :class:`~robotools.liquidhandling.exceptions.VolumeUnderflowError` about underflowing wells.
         kwargs
             Additional keyword arguments to pass to aspirate and dispense.
             Most prominent example: `liquid_class`.
@@ -127,7 +136,7 @@ class FluentWorklist(BaseWorklist):
                     if len(vs) > p:
                         v = vs[p]
                         if v > 0:
-                            self.aspirate(source, s, v, label=None, **kwargs)
+                            self.aspirate(source, s, v, label=None, on_underflow=on_underflow, **kwargs)
                             self.dispense(
                                 destination,
                                 d,

--- a/robotools/liquidhandling/__init__.py
+++ b/robotools/liquidhandling/__init__.py
@@ -1,6 +1,8 @@
 from robotools.liquidhandling.exceptions import (
     VolumeOverflowError,
     VolumeUnderflowError,
+    VolumeUnderflowWarning,
     VolumeViolationException,
+    VolumeViolationWarning,
 )
 from robotools.liquidhandling.labware import Labware, Trough

--- a/robotools/liquidhandling/exceptions.py
+++ b/robotools/liquidhandling/exceptions.py
@@ -5,12 +5,18 @@ from typing import Optional
 __all__ = (
     "VolumeOverflowError",
     "VolumeUnderflowError",
+    "VolumeUnderflowWarning",
     "VolumeViolationException",
+    "VolumeViolationWarning",
 )
 
 
 class VolumeViolationException(Exception):
     """Error indicating a violation of volume constraints."""
+
+
+class VolumeViolationWarning(UserWarning):
+    """Warning indicating the possible violation of volume constratins."""
 
 
 class VolumeOverflowError(VolumeViolationException):
@@ -31,6 +37,10 @@ class VolumeOverflowError(VolumeViolationException):
             )
         else:
             super().__init__(f'Too much volume for "{labware}".{well}: {current} + {change} > {threshold}')
+
+
+class VolumeUnderflowWarning(VolumeViolationWarning):
+    """Warning indicating the possible underflow of a well."""
 
 
 class VolumeUnderflowError(VolumeViolationException):


### PR DESCRIPTION
* :new: `VolumeViolationWarning`, `VolumeUnderflowWarning` were added.
* ✨  New `on_underflow: Literal["debug", "warn", "raise"]` option was added to `Labware.remove`, `BaseWorklist.aspirate`, `EvoWorklist.transfer` and `FluentWorklist.transfer`.
  * Enables aspirating more than the current filling volume without raising `VolumeUnderflowError`.
  * Volume is reduced to no less than `min_volume`.
* ⚙️ Also improves type hints on `BaseWorklist`.
* :gear: Version bumped to v1.13.0 to prepare a release.